### PR TITLE
Fixed bootstrap to directly return BucketNotFound errors.

### DIFF
--- a/configbootstrap_http.go
+++ b/configbootstrap_http.go
@@ -2,6 +2,7 @@ package gocbcorex
 
 import (
 	"context"
+	"errors"
 	"net/http"
 	"time"
 
@@ -131,6 +132,10 @@ func (w ConfigBootstrapHttp) Bootstrap(ctx context.Context) (*ParsedConfig, stri
 			w.bucketName,
 		)
 		if err != nil {
+			if errors.Is(err, cbmgmtx.ErrBucketNotFound) {
+				return nil, "", err
+			}
+
 			attemptErrs[endpoint] = err
 			continue
 		}


### PR DESCRIPTION
The logic for looping during bootstrap was changed to correctly loop multiple nodes.  In order to correctly stop looping when some fatal errors occur, we need to specially handle these.