### PR TITLE
ING-479: Updated the DefaultRetryManager to be the default.

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -142,7 +142,7 @@ func CreateAgent(ctx context.Context, opts AgentOptions) (*Agent, error) {
 		},
 	}
 	if opts.RetryManager == nil {
-		agent.retries = NewRetryManagerFastFail()
+		agent.retries = NewRetryManagerDefault()
 	} else {
 		agent.retries = opts.RetryManager
 	}


### PR DESCRIPTION
It previously was configured to use the FastFailRetryManager by default for an unknown reason in a9a0ae4be26bad85f961f256a2f29735266c7af9.