### PR TITLE
ING-591: Do not check if ReplicaIndexDisabled for ephemeral buckets

### DIFF
--- a/cbmgmtx/mgmt_test.go
+++ b/cbmgmtx/mgmt_test.go
@@ -164,6 +164,7 @@ func TestHttpMgmtBuckets(t *testing.T) {
 		ConflictResolutionType: ConflictResolutionTypeSequenceNumber,
 		BucketType:             BucketTypeCouchbase,
 		StorageBackend:         StorageBackendCouchstore,
+		ReplicaIndex:           true,
 	}
 
 	err := getHttpMgmt().CreateBucket(ctx, &CreateBucketOptions{


### PR DESCRIPTION
Motivation
----------
We currently check if ReplicaIndexDisabled is set, and for ephemeral buckets return an error if so. We should just ignore this field for ephemeral buckets. It's completely reasonable for a user to set the value to true as the server will not allow the replicaIndex field to be set, so it would be expected that setting the field to true could lead to the parameter being omitted in the request. As we cannot distinguish false and not set for the field we cannot take any taken there either.