### PR TITLE
ING-572: Add a fast map to buckets tracking http

### DIFF
--- a/bucketswatcher_http_test.go
+++ b/bucketswatcher_http_test.go
@@ -53,10 +53,10 @@ func TestBucketsWatcherHttp(t *testing.T) {
 		watcher.Watch()
 
 		if assert.Eventuallyf(tt, func() bool {
-			watcher.lock.Lock()
-			defer watcher.lock.Unlock()
+			watcher.slowLock.Lock()
+			defer watcher.slowLock.Unlock()
 
-			return len(watcher.agents) > 0
+			return len(watcher.slowMap) > 0
 		}, 5*time.Second, 100*time.Millisecond, "Watcher failed to create any agents in time specified") {
 
 			_, err = watcher.GetAgent(context.Background(), testutils.TestOpts.BucketName)


### PR DESCRIPTION
Motivation
----------
At the moment if a user calls GetAgent when the tracker is handling detection of new buckets then the call will always block until all new agents are created and old ones destroyed. We should add a fast map so that requests for agents that we already know about can be resolved without waiting for a global lock.