### PR TITLE
ING-598: Add handling for index exists/not found to cbqueryx

### DIFF
--- a/cbqueryx/errors.go
+++ b/cbqueryx/errors.go
@@ -17,6 +17,8 @@ var (
 	ErrPreparedStatementFailure = errors.New("prepared statement failure")
 	ErrDmlFailure               = errors.New("data service returned an error during execution of DML statement")
 	ErrTimeout                  = errors.New("timeout")
+	ErrIndexExists              = errors.New("index exists")
+	ErrIndexNotFound            = errors.New("index not found")
 )
 
 type QueryError struct {

--- a/cbqueryx/query_test.go
+++ b/cbqueryx/query_test.go
@@ -4,9 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"io"
 	"net/http"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/google/uuid"
 
 	"github.com/couchbase/gocbcorex/testutils"
 	"github.com/stretchr/testify/require"
@@ -44,4 +49,74 @@ func TestQuery(t *testing.T) {
 	assertQueryResult(t, expectedRows, &expectedResult, res)
 
 	require.Empty(t, cache.queryCache)
+}
+
+func TestQueryIndexExists(t *testing.T) {
+	index := uuid.NewString()[:6]
+	expectedResult := makeErrorQueryResult([]queryErrorJson{
+		{
+			Code: 4300,
+			Msg:  fmt.Sprintf("The index %s already exists.", index),
+			Reason: map[string]interface{}{
+				"name": index,
+			},
+		},
+	})
+	body, err := json.Marshal(expectedResult)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		Status:        "conflict",
+		StatusCode:    409,
+		Header:        nil,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+
+	opts := &QueryOptions{
+		Statement: fmt.Sprintf("CREATE INDEX %s", index),
+	}
+	_, err = Query{
+		Transport: makeSingleTestRoundTripper(resp, nil),
+		Logger:    testutils.MakeTestLogger(t),
+		UserAgent: "useragent",
+		Username:  "username",
+		Password:  "password",
+	}.Query(context.Background(), opts)
+	assert.ErrorIs(t, err, ErrIndexExists)
+}
+
+func TestQueryIndexNotFound(t *testing.T) {
+	index := uuid.NewString()[:6]
+	expectedResult := makeErrorQueryResult([]queryErrorJson{
+		{
+			Code: 12016,
+			Msg:  fmt.Sprintf("Index Not Found - cause: GSI index %s not found.", index),
+			Reason: map[string]interface{}{
+				"name": index,
+			},
+		},
+	})
+	body, err := json.Marshal(expectedResult)
+	require.NoError(t, err)
+
+	resp := &http.Response{
+		Status:        "success",
+		StatusCode:    200,
+		Header:        nil,
+		Body:          io.NopCloser(bytes.NewReader(body)),
+		ContentLength: int64(len(body)),
+	}
+
+	opts := &QueryOptions{
+		Statement: fmt.Sprintf("CREATE INDEX %s", index),
+	}
+	_, err = Query{
+		Transport: makeSingleTestRoundTripper(resp, nil),
+		Logger:    testutils.MakeTestLogger(t),
+		UserAgent: "useragent",
+		Username:  "username",
+		Password:  "password",
+	}.Query(context.Background(), opts)
+	assert.ErrorIs(t, err, ErrIndexNotFound)
 }

--- a/cbqueryx/queryrespreader.go
+++ b/cbqueryx/queryrespreader.go
@@ -126,6 +126,14 @@ func (r *queryRespReader) parseError(errJson *queryErrorJson) *QueryServerError 
 		err = ErrIndexFailure
 	}
 
+	if errCode == 4300 {
+		err = ErrIndexExists
+	}
+
+	if errCode == 12016 {
+		err = ErrIndexNotFound
+	}
+
 	if errCode == 4040 || errCode == 4050 || errCode == 4060 || errCode == 4070 || errCode == 4080 || errCode == 4090 {
 		err = ErrPreparedStatementFailure
 	}

--- a/cbqueryx/utils_test.go
+++ b/cbqueryx/utils_test.go
@@ -51,10 +51,12 @@ type testQueryResult struct {
 		ResultCount   uint64 `json:"resultCount"`
 		ResultSize    uint64 `json:"resultSize"`
 		ServiceLoad   int    `json:"serviceLoad"`
+		ErrorCount    int    `json:"errorCount"`
 	} `json:"metrics"`
-	Prepared string          `json:"prepared,omitempty"`
-	Results  json.RawMessage `json:"results"`
-	Status   string          `json:"status"`
+	Prepared string           `json:"prepared,omitempty"`
+	Results  json.RawMessage  `json:"results"`
+	Errors   []queryErrorJson `json:"errors,omitempty"`
+	Status   string           `json:"status"`
 }
 
 func assertQueryResult(t *testing.T, expectedRows []string, expectedResult *testQueryResult, res QueryResultStream) {
@@ -113,6 +115,7 @@ func makeSuccessQueryResult(rows []string, prepared string) testQueryResult {
 			ResultCount   uint64 `json:"resultCount"`
 			ResultSize    uint64 `json:"resultSize"`
 			ServiceLoad   int    `json:"serviceLoad"`
+			ErrorCount    int    `json:"errorCount"`
 		}{
 			ElapsedTime:   "129.569043ms",
 			ExecutionTime: "129.521515ms",
@@ -123,6 +126,33 @@ func makeSuccessQueryResult(rows []string, prepared string) testQueryResult {
 	}
 	if prepared != "" {
 		qr.Prepared = prepared
+	}
+
+	return qr
+}
+
+func makeErrorQueryResult(errors []queryErrorJson) testQueryResult {
+	qr := testQueryResult{
+		Results:         json.RawMessage("[]"),
+		RequestID:       "941e33f4-15d8-44d0-a5a8-422e3e84039f",
+		ClientContextID: "12345",
+		Status:          "errors",
+		Metrics: struct {
+			ElapsedTime   string `json:"elapsedTime"`
+			ExecutionTime string `json:"executionTime"`
+			ResultCount   uint64 `json:"resultCount"`
+			ResultSize    uint64 `json:"resultSize"`
+			ServiceLoad   int    `json:"serviceLoad"`
+			ErrorCount    int    `json:"errorCount"`
+		}{
+			ElapsedTime:   "129.569043ms",
+			ExecutionTime: "129.521515ms",
+			ResultCount:   0,
+			ResultSize:    0,
+			ServiceLoad:   2,
+			ErrorCount:    1,
+		},
+		Errors: errors,
 	}
 
 	return qr


### PR DESCRIPTION
Motivation
----------
We need to expose index exists and not found from cbqueryx, and add handling for their respective error codes. This will enable users to be able to handle these errors without having to manually parse the error that we return.