### PR TITLE
ING-603: Use HTTP poller for cluster level agents

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -178,7 +178,7 @@ func CreateAgent(ctx context.Context, opts AgentOptions) (*Agent, error) {
 	})
 	agent.vbRouter.UpdateRoutingInfo(agentComponentConfigs.VbucketRoutingInfo)
 
-	if false {
+	if opts.BucketName == "" {
 		configWatcher, err := NewConfigWatcherHttp(
 			&agentComponentConfigs.ConfigWatcherHttpConfig,
 			&ConfigWatcherHttpOptions{


### PR DESCRIPTION
Motivation
----------
At the moment we always use CCCP polling, for agents with no buckets we do not create any memcached connections. This means that those agents never receive config updates. We should use HTTP polling for those agents.