### PR TITLE
ING-580 Remove Query prefix from cbqueryx types

### DIFF
--- a/cbqueryx/errors.go
+++ b/cbqueryx/errors.go
@@ -21,26 +21,26 @@ var (
 	ErrIndexNotFound            = errors.New("index not found")
 )
 
-type QueryError struct {
+type Error struct {
 	Cause error
 
 	StatusCode      int
 	Endpoint        string
 	Statement       string
 	ClientContextId string
-	ErrorDescs      []QueryErrorDesc
+	ErrorDescs      []ErrorDesc
 }
 
-func (e QueryError) Error() string {
+func (e Error) Error() string {
 	return fmt.Sprintf("query server error: %s", e.Cause.Error())
 }
 
-func (e QueryError) Unwrap() error {
+func (e Error) Unwrap() error {
 	return e.Cause
 }
 
-// QueryErrorDesc represents specific n1ql error data.
-type QueryErrorDesc struct {
+// ErrorDesc represents specific n1ql error data.
+type ErrorDesc struct {
 	// Error is populated if the SDK understand what this error desc is.
 	Error   error
 	Code    uint32
@@ -62,30 +62,30 @@ func (e contextualError) Unwrap() error {
 	return e.Cause
 }
 
-type QueryServerError struct {
+type ServerError struct {
 	InnerError error
 	Code       uint32
 	Msg        string
 }
 
-func (e QueryServerError) Error() string {
+func (e ServerError) Error() string {
 	return fmt.Sprintf("query error: %s (code: %d, msg: %s)",
 		e.InnerError.Error(),
 		e.Code, e.Msg)
 }
 
-func (e QueryServerError) Unwrap() error {
+func (e ServerError) Unwrap() error {
 	return e.InnerError
 }
 
-type QueryServerErrors struct {
-	Errors []*QueryServerError
+type ServerErrors struct {
+	Errors []*ServerError
 }
 
-func (e QueryServerErrors) Error() string {
+func (e ServerErrors) Error() string {
 	return fmt.Sprintf("%s (+ %d other errors)", e.Errors[0].Error(), len(e.Errors)-1)
 }
 
-func (e QueryServerErrors) Unwrap() error {
+func (e ServerErrors) Unwrap() error {
 	return e.Errors[0]
 }

--- a/cbqueryx/preparedquery.go
+++ b/cbqueryx/preparedquery.go
@@ -4,16 +4,16 @@ import (
 	"context"
 )
 
-type QueryExecutor interface {
-	Query(ctx context.Context, opts *QueryOptions) (QueryResultStream, error)
+type Executor interface {
+	Query(ctx context.Context, opts *Options) (ResultStream, error)
 }
 
 type PreparedQuery struct {
-	Executor QueryExecutor
+	Executor Executor
 	Cache    *PreparedStatementCache
 }
 
-func (p PreparedQuery) PreparedQuery(ctx context.Context, opts *QueryOptions) (QueryResultStream, error) {
+func (p PreparedQuery) PreparedQuery(ctx context.Context, opts *Options) (ResultStream, error) {
 	newOpts := *opts
 
 	// if this is already marked as auto-execute, we just pass it through

--- a/cbqueryx/preparedquery_test.go
+++ b/cbqueryx/preparedquery_test.go
@@ -31,7 +31,7 @@ func TestPreparedQuery(t *testing.T) {
 		ContentLength: int64(len(body)),
 	}
 	cache := NewPreparedStatementCache()
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: "SELECT 1",
 	}
 	rt := makeSingleTestRoundTripper(resp, nil)
@@ -81,7 +81,7 @@ func TestPreparedQueryAlreadyCached(t *testing.T) {
 		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
 	}
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: "SELECT 1",
 	}
 	cache := NewPreparedStatementCache()
@@ -133,7 +133,7 @@ func TestPreparedQueryAlreadyCachedVersionFails(t *testing.T) {
 		Body:          io.NopCloser(bytes.NewReader(body)),
 		ContentLength: int64(len(body)),
 	}
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: "SELECT 1",
 	}
 	cache := NewPreparedStatementCache()
@@ -185,7 +185,7 @@ func TestPreparedQueryPreparedNameMissing(t *testing.T) {
 		ContentLength: int64(len(body)),
 	}
 	cache := NewPreparedStatementCache()
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: "SELECT 1",
 	}
 	rt := makeSingleTestRoundTripper(resp, nil)

--- a/cbqueryx/query.go
+++ b/cbqueryx/query.go
@@ -50,14 +50,14 @@ func (h Query) Execute(
 	}.Do(req)
 }
 
-type QueryResultStream interface {
-	EarlyMetaData() *QueryEarlyMetaData
+type ResultStream interface {
+	EarlyMetaData() *EarlyMetaData
 	HasMoreRows() bool
 	ReadRow() (json.RawMessage, error)
-	MetaData() (*QueryMetaData, error)
+	MetaData() (*MetaData, error)
 }
 
-func (h Query) Query(ctx context.Context, opts *QueryOptions) (QueryResultStream, error) {
+func (h Query) Query(ctx context.Context, opts *Options) (ResultStream, error) {
 	reqBytes, err := opts.encodeToJson()
 	if err != nil {
 		return nil, err

--- a/cbqueryx/query_json.go
+++ b/cbqueryx/query_json.go
@@ -2,19 +2,19 @@ package cbqueryx
 
 import "encoding/json"
 
-type QueryStatus string
+type Status string
 
 const (
-	QueryStatusRunning   QueryStatus = "running"
-	QueryStatusSuccess   QueryStatus = "success"
-	QueryStatusErrors    QueryStatus = "errors"
-	QueryStatusCompleted QueryStatus = "completed"
-	QueryStatusStopped   QueryStatus = "stopped"
-	QueryStatusTimeout   QueryStatus = "timeout"
-	QueryStatusClosed    QueryStatus = "closed"
-	QueryStatusFatal     QueryStatus = "fatal"
-	QueryStatusAborted   QueryStatus = "aborted"
-	QueryStatusUnknown   QueryStatus = "unknown"
+	QueryStatusRunning   Status = "running"
+	QueryStatusSuccess   Status = "success"
+	QueryStatusErrors    Status = "errors"
+	QueryStatusCompleted Status = "completed"
+	QueryStatusStopped   Status = "stopped"
+	QueryStatusTimeout   Status = "timeout"
+	QueryStatusClosed    Status = "closed"
+	QueryStatusFatal     Status = "fatal"
+	QueryStatusAborted   Status = "aborted"
+	QueryStatusUnknown   Status = "unknown"
 )
 
 type queryErrorResponseJson struct {
@@ -29,7 +29,7 @@ type queryMetaDataJson struct {
 	queryEarlyMetaDataJson
 	RequestID       string              `json:"requestID,omitempty"`
 	ClientContextID string              `json:"clientContextID,omitempty"`
-	Status          QueryStatus         `json:"status,omitempty"`
+	Status          Status              `json:"status,omitempty"`
 	Errors          []*queryErrorJson   `json:"errors,omitempty"`
 	Warnings        []*queryWarningJson `json:"warnings,omitempty"`
 	Metrics         *queryMetricsJson   `json:"metrics,omitempty"`

--- a/cbqueryx/query_options.go
+++ b/cbqueryx/query_options.go
@@ -7,98 +7,98 @@ import (
 	"github.com/couchbase/gocbcorex/cbhttpx"
 )
 
-type QueryScanConsistency string
+type ScanConsistency string
 
 const (
-	QueryScanConsistencyUnset       QueryScanConsistency = ""
-	QueryScanConsistencyNotBounded  QueryScanConsistency = "not_bounded"
-	QueryScanConsistencyRequestPlus QueryScanConsistency = "request_plus"
+	QueryScanConsistencyUnset       ScanConsistency = ""
+	QueryScanConsistencyNotBounded  ScanConsistency = "not_bounded"
+	QueryScanConsistencyRequestPlus ScanConsistency = "request_plus"
 )
 
-type QueryProfileMode string
+type ProfileMode string
 
 const (
-	QueryProfileModeUnset   QueryProfileMode = ""
-	QueryProfileModeOff     QueryProfileMode = "off"
-	QueryProfileModePhases  QueryProfileMode = "phases"
-	QueryProfileModeTimings QueryProfileMode = "timings"
+	QueryProfileModeUnset   ProfileMode = ""
+	QueryProfileModeOff     ProfileMode = "off"
+	QueryProfileModePhases  ProfileMode = "phases"
+	QueryProfileModeTimings ProfileMode = "timings"
 )
 
-type QueryCompression string
+type Compression string
 
 const (
-	QueryCompressionUnset QueryCompression = ""
-	QueryCompressionZip   QueryCompression = "ZIP"
-	QueryCompressionRle   QueryCompression = "RLE"
-	QueryCompressionLzma  QueryCompression = "LZMA"
-	QueryCompressionLzo   QueryCompression = "LZO"
-	QueryCompressionNone  QueryCompression = "NONE"
+	QueryCompressionUnset Compression = ""
+	QueryCompressionZip   Compression = "ZIP"
+	QueryCompressionRle   Compression = "RLE"
+	QueryCompressionLzma  Compression = "LZMA"
+	QueryCompressionLzo   Compression = "LZO"
+	QueryCompressionNone  Compression = "NONE"
 )
 
-type QueryDurabilityLevel string
+type DurabilityLevel string
 
 const (
-	QueryDurabilityLevelUnset                    QueryDurabilityLevel = ""
-	QueryDurabilityLevelNone                     QueryDurabilityLevel = "none"
-	QueryDurabilityLevelMajority                 QueryDurabilityLevel = "majority"
-	QueryDurabilityLevelMajorityAndPersistActive QueryDurabilityLevel = "majorityAndPersistActive"
-	QueryDurabilityLevelPersistToMajority        QueryDurabilityLevel = "persistToMajority"
+	QueryDurabilityLevelUnset                    DurabilityLevel = ""
+	QueryDurabilityLevelNone                     DurabilityLevel = "none"
+	QueryDurabilityLevelMajority                 DurabilityLevel = "majority"
+	QueryDurabilityLevelMajorityAndPersistActive DurabilityLevel = "majorityAndPersistActive"
+	QueryDurabilityLevelPersistToMajority        DurabilityLevel = "persistToMajority"
 )
 
-type QueryEncoding string
+type Encoding string
 
 const (
-	QueryEncodingUnset QueryEncoding = ""
-	QueryEncodingUtf8  QueryEncoding = "UTF-8"
+	QueryEncodingUnset Encoding = ""
+	QueryEncodingUtf8  Encoding = "UTF-8"
 )
 
-type QueryFormat string
+type Format string
 
 const (
-	QueryFormatUnset QueryFormat = ""
-	QueryFormatJson  QueryFormat = "JSON"
-	QueryFormatXml   QueryFormat = "XML"
-	QueryFormatCsv   QueryFormat = "CSV"
-	QueryFormatTsv   QueryFormat = "TSV"
+	QueryFormatUnset Format = ""
+	QueryFormatJson  Format = "JSON"
+	QueryFormatXml   Format = "XML"
+	QueryFormatCsv   Format = "CSV"
+	QueryFormatTsv   Format = "TSV"
 )
 
-type QueryCredsJson struct {
+type CredsJson struct {
 	User string `json:"user,omitempty"`
 	Pass string `json:"pass,omitempty"`
 }
 
-type QueryScanVectorEntry struct {
+type ScanVectorEntry struct {
 	SeqNo  uint64
 	VbUuid string
 }
 
-func (e QueryScanVectorEntry) MarshalJSON() ([]byte, error) {
+func (e ScanVectorEntry) MarshalJSON() ([]byte, error) {
 	return json.Marshal([]interface{}{e.SeqNo, e.VbUuid})
 }
 
-func (e QueryScanVectorEntry) UnmarshalJSON(data []byte) error {
+func (e ScanVectorEntry) UnmarshalJSON(data []byte) error {
 	return nil
 }
 
-var _ json.Marshaler = (*QueryScanVectorEntry)(nil)
-var _ json.Unmarshaler = (*QueryScanVectorEntry)(nil)
+var _ json.Marshaler = (*ScanVectorEntry)(nil)
+var _ json.Unmarshaler = (*ScanVectorEntry)(nil)
 
-type QueryFullScanVectors []QueryScanVectorEntry
+type FullScanVectors []ScanVectorEntry
 
-type QuerySparseScanVectors map[uint32]QueryScanVectorEntry
+type SparseScanVectors map[uint32]ScanVectorEntry
 
-type QueryOptions struct {
+type Options struct {
 	Args            []json.RawMessage
 	AtrCollection   string
 	AutoExecute     bool
 	ClientContextId string
-	Compression     QueryCompression
+	Compression     Compression
 	Controls        bool
-	Creds           []QueryCredsJson
-	DurabilityLevel QueryDurabilityLevel
+	Creds           []CredsJson
+	DurabilityLevel DurabilityLevel
 	EncodedPlan     string
-	Encoding        QueryEncoding
-	Format          QueryFormat
+	Encoding        Encoding
+	Format          Format
 	KvTimeout       time.Duration
 	MaxParallelism  uint32
 	MemoryQuota     uint32
@@ -110,11 +110,11 @@ type QueryOptions struct {
 	Prepared        string
 	PreserveExpiry  bool
 	Pretty          bool
-	Profile         QueryProfileMode
+	Profile         ProfileMode
 	QueryContext    string
 	ReadOnly        bool
 	ScanCap         uint32
-	ScanConsistency QueryScanConsistency
+	ScanConsistency ScanConsistency
 	ScanVector      json.RawMessage
 	ScanVectors     map[string]json.RawMessage
 	ScanWait        time.Duration
@@ -135,7 +135,7 @@ type QueryOptions struct {
 	OnBehalfOf *cbhttpx.OnBehalfOfInfo
 }
 
-func (o *QueryOptions) encodeToJson() (json.RawMessage, error) {
+func (o *Options) encodeToJson() (json.RawMessage, error) {
 	var anyErr error
 
 	m := make(map[string]json.RawMessage)

--- a/cbqueryx/query_options_test.go
+++ b/cbqueryx/query_options_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 func TestEncodeQueryOptions(t *testing.T) {
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: "SELECT *",
 	}
 

--- a/cbqueryx/query_results.go
+++ b/cbqueryx/query_results.go
@@ -2,28 +2,28 @@ package cbqueryx
 
 import "time"
 
-type QueryEarlyMetaData struct {
+type EarlyMetaData struct {
 	Prepared string
 }
 
-type QueryMetaData struct {
-	QueryEarlyMetaData
+type MetaData struct {
+	EarlyMetaData
 
 	RequestID       string
 	ClientContextID string
-	Status          QueryStatus
-	Metrics         QueryMetrics
+	Status          Status
+	Metrics         Metrics
 	Signature       interface{}
-	Warnings        []QueryWarning
+	Warnings        []Warning
 	Profile         interface{}
 }
 
-type QueryWarning struct {
+type Warning struct {
 	Code    uint32
 	Message string
 }
 
-type QueryMetrics struct {
+type Metrics struct {
 	ElapsedTime   time.Duration
 	ExecutionTime time.Duration
 	ResultCount   uint64

--- a/cbqueryx/query_test.go
+++ b/cbqueryx/query_test.go
@@ -34,7 +34,7 @@ func TestQuery(t *testing.T) {
 		ContentLength: int64(len(body)),
 	}
 	cache := NewPreparedStatementCache()
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: "SELECT 1",
 	}
 	res, err := Query{

--- a/cbqueryx/query_test.go
+++ b/cbqueryx/query_test.go
@@ -73,7 +73,7 @@ func TestQueryIndexExists(t *testing.T) {
 		ContentLength: int64(len(body)),
 	}
 
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: fmt.Sprintf("CREATE INDEX %s", index),
 	}
 	_, err = Query{
@@ -108,7 +108,7 @@ func TestQueryIndexNotFound(t *testing.T) {
 		ContentLength: int64(len(body)),
 	}
 
-	opts := &QueryOptions{
+	opts := &Options{
 		Statement: fmt.Sprintf("CREATE INDEX %s", index),
 	}
 	_, err = Query{

--- a/cbqueryx/utils_test.go
+++ b/cbqueryx/utils_test.go
@@ -59,7 +59,7 @@ type testQueryResult struct {
 	Status   string           `json:"status"`
 }
 
-func assertQueryResult(t *testing.T, expectedRows []string, expectedResult *testQueryResult, res QueryResultStream) {
+func assertQueryResult(t *testing.T, expectedRows []string, expectedResult *testQueryResult, res ResultStream) {
 	var rows [][]byte
 	for {
 		row, err := res.ReadRow()
@@ -80,7 +80,7 @@ func assertQueryResult(t *testing.T, expectedRows []string, expectedResult *test
 	meta, err := res.MetaData()
 	require.NoError(t, err)
 
-	assert.Equal(t, QueryStatus(expectedResult.Status), meta.Status)
+	assert.Equal(t, Status(expectedResult.Status), meta.Status)
 	assert.Equal(t, expectedResult.ClientContextID, meta.ClientContextID)
 	assert.Equal(t, expectedResult.RequestID, meta.RequestID)
 

--- a/querycomponent.go
+++ b/querycomponent.go
@@ -8,8 +8,8 @@ import (
 	"go.uber.org/zap"
 )
 
-type QueryOptions = cbqueryx.QueryOptions
-type QueryResultStream = cbqueryx.QueryResultStream
+type QueryOptions = cbqueryx.Options
+type QueryResultStream = cbqueryx.ResultStream
 type PreparedStatementCache = cbqueryx.PreparedStatementCache
 
 type QueryComponent struct {


### PR DESCRIPTION
Currently there are various types in cbqueryx that are prefixed with Query. This results in the types, when called outside of the package taking the form: `cbquery.Query` which is somewhat redundant.