### PR TITLE
ING-500 Add new errors to propagate to stellar-gateway

### DIFF
--- a/cbmgmtx/errors.go
+++ b/cbmgmtx/errors.go
@@ -14,6 +14,7 @@ var (
 	ErrCollectionNotFound = errors.New("collection not found")
 	ErrBucketExists       = errors.New("bucket exists")
 	ErrBucketNotFound     = errors.New("bucket not found")
+	ErrServerInvalidArg   = errors.New("invalid argument")
 )
 
 type ServerError struct {
@@ -41,4 +42,17 @@ func (e contextualError) Error() string {
 
 func (e contextualError) Unwrap() error {
 	return e.Cause
+}
+
+type ServerInvalidArgError struct {
+	Argument string
+	Reason   string
+}
+
+func (e ServerInvalidArgError) Unwrap() error {
+	return ErrServerInvalidArg
+}
+
+func (e ServerInvalidArgError) Error() string {
+	return fmt.Sprintf("%s: %s - %s", e.Unwrap().Error(), e.Argument, e.Reason)
 }

--- a/cbmgmtx/mgmt_test.go
+++ b/cbmgmtx/mgmt_test.go
@@ -221,3 +221,39 @@ func TestHttpMgmtBuckets(t *testing.T) {
 	})
 	require.ErrorIs(t, err, ErrBucketNotFound)
 }
+
+func Test_parseForInvalidArg(t *testing.T) {
+	errTextStart := `{"errors":{`
+	errTextEnd := `},"summaries":{"ramSummary":{"total":3028287488,"otherBuckets":0,
+	"nodesCount":1,"perNodeMegs":100,"thisAlloc":104857600,"thisUsed":0,"free":2923429888},
+	"hddSummary":{"total":63089455104,"otherData":5047156408,"otherBuckets":0,"thisUsed":0,
+	"free":58042298696}}}`
+
+	t.Run("single field in chain", func(t *testing.T) {
+		errText := errTextStart + `"fieldOne":"reasonOne"` + errTextEnd
+		sErr := parseForInvalidArg(errText)
+		assert.Equal(t, "fieldOne", sErr.Argument)
+		assert.Equal(t, "reasonOne", sErr.Reason)
+	})
+
+	t.Run("multiple fields in chain", func(t *testing.T) {
+		errText := errTextStart + `"fieldOne":"reasonOne","fieldTwo":"reasonTwo"` + errTextEnd
+		sErr := parseForInvalidArg(errText)
+		assert.Equal(t, "fieldOne", sErr.Argument)
+		assert.Equal(t, "reasonOne", sErr.Reason)
+	})
+
+	t.Run("single field in chain - commas in reason", func(t *testing.T) {
+		errText := errTextStart + `"fieldOne":"reasonOne, something else"` + errTextEnd
+		sErr := parseForInvalidArg(errText)
+		assert.Equal(t, "fieldOne", sErr.Argument)
+		assert.Equal(t, "reasonOne, something else", sErr.Reason)
+	})
+
+	t.Run("multiple fields in chain - commas in reasons", func(t *testing.T) {
+		errText := errTextStart + `"fieldOne":"reasonOne, something else","fieldTwo":"reason, something"` + errTextEnd
+		sErr := parseForInvalidArg(errText)
+		assert.Equal(t, "fieldOne", sErr.Argument)
+		assert.Equal(t, "reasonOne, something else", sErr.Reason)
+	})
+}


### PR DESCRIPTION
In order to make the errors returned by stellar-gateway more informative we first need to make the errors returned by gocbcorex distinguishable for the cases highlighted in ING-500