### PR TITLE
ING-453 Return DocExistsErr when NotStored status returned from MutateIn

### DIFF
--- a/memdx/errors.go
+++ b/memdx/errors.go
@@ -15,6 +15,7 @@ var (
 	ErrCollectionsNotEnabled               = errors.New("collections not enabled")
 	ErrDocNotFound                         = errors.New("document not found")
 	ErrDocExists                           = errors.New("document already exists")
+	ErrDocNotStored                        = errors.New("document not stored")
 	ErrValueTooLarge                       = errors.New("value too large")
 	ErrAuthError                           = errors.New("auth error")
 	ErrNotMyVbucket                        = errors.New("not my vbucket")

--- a/memdx/ops_crud.go
+++ b/memdx/ops_crud.go
@@ -2080,6 +2080,14 @@ func (o OpsCrud) MutateIn(d Dispatcher, req *MutateInRequest, cb func(*MutateInR
 		} else if resp.Status == StatusSyncWriteReCommitInProgress {
 			cb(nil, ErrSyncWriteReCommitInProgress)
 			return false
+		} else if resp.Status == StatusNotStored {
+			if req.Flags == SubdocDocFlagAddDoc {
+				cb(nil, ErrDocExists)
+				return false
+			}
+
+			cb(nil, ErrDocNotStored)
+			return false
 		} else if resp.Status == StatusSubDocMultiPathFailure {
 			if len(resp.Value) != 3 {
 				cb(nil, protocolError{"bad value length"})


### PR DESCRIPTION
MutateIn with Insert semantics can return NotStored. This should be changed so that we handle NotStored in gocbcorex for a MutateIn with Insert semantics by converting it into a DocAlreadyExists error. 