### PR TITLE
ING-624 Handle SyncWriteInProgress status

### DIFF
--- a/memdx/errors.go
+++ b/memdx/errors.go
@@ -48,6 +48,7 @@ var (
 	ErrSubDocXattrUnknownVattrMacro        = errors.New("subdoc xattr unknown vattr macro")
 	ErrSubDocCanOnlyReviveDeletedDocuments = errors.New("subdoc can only revive deleted documents")
 	ErrSubDocDeletedDocumentCantHaveValue  = errors.New("subdoc deleted document cant have value")
+	ErrSyncWriteInProgress                 = errors.New("sync write in progress")
 	ErrTmpFail                             = errors.New("temporary failure")
 
 	ErrClosedInFlight = errors.New("connection closed whilst operation in flight")

--- a/memdx/ops_crud.go
+++ b/memdx/ops_crud.go
@@ -2074,6 +2074,9 @@ func (o OpsCrud) MutateIn(d Dispatcher, req *MutateInRequest, cb func(*MutateInR
 		} else if resp.Status == StatusSubDocDeletedDocumentCantHaveValue {
 			cb(nil, ErrSubDocDeletedDocumentCantHaveValue)
 			return false
+		} else if resp.Status == StatusSyncWriteInProgress {
+			cb(nil, ErrSyncWriteInProgress)
+			return false
 		} else if resp.Status == StatusSubDocMultiPathFailure {
 			if len(resp.Value) != 3 {
 				cb(nil, protocolError{"bad value length"})


### PR DESCRIPTION
Currently when we attempt to perform concurrent mutate operations with insert semantics we get an internal server error returned to the User. Instead we should handle the status and return a more useful error to STG