### PR TITLE
ING-630 Handle SyncWriteReCommitInProgress status

### DIFF
--- a/memdx/errors.go
+++ b/memdx/errors.go
@@ -49,6 +49,7 @@ var (
 	ErrSubDocCanOnlyReviveDeletedDocuments = errors.New("subdoc can only revive deleted documents")
 	ErrSubDocDeletedDocumentCantHaveValue  = errors.New("subdoc deleted document cant have value")
 	ErrSyncWriteInProgress                 = errors.New("sync write in progress")
+	ErrSyncWriteReCommitInProgress         = errors.New("sync write recommit in progress")
 	ErrTmpFail                             = errors.New("temporary failure")
 
 	ErrClosedInFlight = errors.New("connection closed whilst operation in flight")

--- a/memdx/ops_crud.go
+++ b/memdx/ops_crud.go
@@ -2077,6 +2077,9 @@ func (o OpsCrud) MutateIn(d Dispatcher, req *MutateInRequest, cb func(*MutateInR
 		} else if resp.Status == StatusSyncWriteInProgress {
 			cb(nil, ErrSyncWriteInProgress)
 			return false
+		} else if resp.Status == StatusSyncWriteReCommitInProgress {
+			cb(nil, ErrSyncWriteReCommitInProgress)
+			return false
 		} else if resp.Status == StatusSubDocMultiPathFailure {
 			if len(resp.Value) != 3 {
 				cb(nil, protocolError{"bad value length"})


### PR DESCRIPTION
Currently if gocbcorex receives a a SyncRecommitInProgress status this will not be handled by gocbcorex and an unknown error will be returned. Instead we should handle this status and return an appropriate error.