### PR TITLE
Updated golangci-lint version.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           go-version: 1.19
       - run: |
-          go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.50.1
           go install golang.org/x/tools/cmd/goimports@latest
       - name: goimports
         run: |
@@ -30,5 +29,5 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.51
+          version: v1.55
           args: --timeout=3m


### PR DESCRIPTION
This resolves an issue with being able to scan one of the new commits.