### PR TITLE
ING-654: Fix flakiness in Test_parseForInvalidArg

### DIFF
--- a/cbmgmtx/mgmt_test.go
+++ b/cbmgmtx/mgmt_test.go
@@ -239,8 +239,13 @@ func Test_parseForInvalidArg(t *testing.T) {
 	t.Run("multiple fields in chain", func(t *testing.T) {
 		errText := errTextStart + `"fieldOne":"reasonOne","fieldTwo":"reasonTwo"` + errTextEnd
 		sErr := parseForInvalidArg(errText)
-		assert.Equal(t, "fieldOne", sErr.Argument)
-		assert.Equal(t, "reasonOne", sErr.Reason)
+		isFirstError := sErr.Argument == "fieldOne"
+		if isFirstError {
+			assert.Equal(t, sErr.Reason, "reasonOne")
+		} else {
+			assert.Equal(t, sErr.Argument, "fieldTwo")
+			assert.Equal(t, sErr.Reason, "reasonTwo")
+		}
 	})
 
 	t.Run("single field in chain - commas in reason", func(t *testing.T) {
@@ -255,5 +260,12 @@ func Test_parseForInvalidArg(t *testing.T) {
 		sErr := parseForInvalidArg(errText)
 		assert.Equal(t, "fieldOne", sErr.Argument)
 		assert.Equal(t, "reasonOne, something else", sErr.Reason)
+		isFirstError := sErr.Argument == "fieldOne"
+		if isFirstError {
+			assert.Equal(t, sErr.Reason, "reasonOne, something else")
+		} else {
+			assert.Equal(t, sErr.Argument, "fieldTwo")
+			assert.Equal(t, sErr.Reason, "reason, something")
+		}
 	})
 }


### PR DESCRIPTION
Test_parseForInvalidArg can sometimes fail. This is due using json.Unmarshal into a map does preserve the order present in the underlying JSON making the value that we expect invalid. This is fine in terms of behaviour, since we don’t mind which error we return, it’s only an issue for the unit test.