### PR TITLE
ING-659: Move where agent config watcher is started

### DIFF
--- a/agent.go
+++ b/agent.go
@@ -207,8 +207,6 @@ func CreateAgent(ctx context.Context, opts AgentOptions) (*Agent, error) {
 		agent.cfgWatcher = configWatcher
 	}
 
-	agent.startConfigWatcher()
-
 	agent.crud = &CrudComponent{
 		logger:      agent.logger,
 		collections: agent.collections,
@@ -247,6 +245,8 @@ func CreateAgent(ctx context.Context, opts AgentOptions) (*Agent, error) {
 			UserAgent: httpUserAgent,
 		},
 	)
+
+	agent.startConfigWatcher()
 
 	return agent, nil
 }


### PR DESCRIPTION
Motivation
----------
At the moment the config watcher is started before all of the agent components have been assigned. This can lead to a data race between assigning them and applying a config.