### PR TITLE
ING-656: Support collection updating

### DIFF
--- a/agent_ops.go
+++ b/agent_ops.go
@@ -150,6 +150,10 @@ func (agent *Agent) DeleteCollection(ctx context.Context, opts *cbmgmtx.DeleteCo
 	return agent.mgmt.DeleteCollection(ctx, opts)
 }
 
+func (agent *Agent) UpdateCollection(ctx context.Context, opts *cbmgmtx.UpdateCollectionOptions) (*cbmgmtx.UpdateCollectionResponse, error) {
+	return agent.mgmt.UpdateCollection(ctx, opts)
+}
+
 func (agent *Agent) EnsureManifest(ctx context.Context, opts *EnsureManifestOptions) error {
 	return agent.mgmt.EnsureManifest(ctx, opts)
 }

--- a/mgmtcomponent.go
+++ b/mgmtcomponent.go
@@ -127,6 +127,10 @@ func (w *MgmtComponent) DeleteCollection(ctx context.Context, opts *cbmgmtx.Dele
 	return OrchestrateSimpleMgmtCall(ctx, w, cbmgmtx.Management.DeleteCollection, opts)
 }
 
+func (w *MgmtComponent) UpdateCollection(ctx context.Context, opts *cbmgmtx.UpdateCollectionOptions) (*cbmgmtx.UpdateCollectionResponse, error) {
+	return OrchestrateSimpleMgmtCall(ctx, w, cbmgmtx.Management.UpdateCollection, opts)
+}
+
 func (w *MgmtComponent) GetAllBuckets(ctx context.Context, opts *cbmgmtx.GetAllBucketsOptions) ([]*cbmgmtx.BucketDef, error) {
 	return OrchestrateSimpleMgmtCall(ctx, w, cbmgmtx.Management.GetAllBuckets, opts)
 }


### PR DESCRIPTION
I had to add the special error parsing as the errors returned from the server is different between 7.2 `({"errors":{"history":"bucket must have storage_mode=magma, not couchstore"}})` and 7.6 `not allowed on this type of bucket`

WIP as awainting the merge of related Protostellar changes