### PR TITLE
Limit tests in CI to only run a single package at a time

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
           CBDC_CONNSTR: # from above
           GCBDINOID: ${{ env.CBDC_ID }}
           GCBCONNSTR: ${{ env.CBDC_CONNSTR }}
-        run: go test ./... -v -race
+        run: go test ./... -v -race -p 1
 
       - name: Collect couchbase logs
         timeout-minutes: 10


### PR DESCRIPTION
Tests can randomly fail due to our usage of cbdinocluster impacting tests within different packages running in parallel.