### PR TITLE
ING-717: Correct analyse doc URI construction

### DIFF
--- a/cbsearchx/search.go
+++ b/cbsearchx/search.go
@@ -335,7 +335,7 @@ func (h Search) AnalyzeDocument(
 		if opts.ScopeName == "" || opts.BucketName == "" {
 			return nil, errors.New("must specify both or neither of scope and bucket names")
 		}
-		reqURI = fmt.Sprintf("/api/bucket/%s/scope/%s/index/%s/analyzeDoc", opts.BucketName, opts.ScopeName, opts.IndexName)
+		reqURI = fmt.Sprintf("/api/index/%s.%s.%s/analyzeDoc", opts.BucketName, opts.ScopeName, opts.IndexName)
 	}
 
 	resp, err := h.Execute(


### PR DESCRIPTION
When performing document analysis against a scoped search index we currently construct the URI as with other search index operations. This leads to a page that does not exist, instead we need to include the fully qualified index name in the URI. The test to validate this works is being added in ING-677.