### PR TITLE
ING-689: Prevent goroutine leak when client close fails

### DIFF
--- a/memdx/harness_test.go
+++ b/memdx/harness_test.go
@@ -36,13 +36,15 @@ func createTestClient(t *testing.T) *Client {
 	address := config.VBucketServerMap.ServerList[vbIdx]
 
 	if testAddress != address {
-		cli.Close()
+		err := cli.Close()
+		require.NoError(t, err)
 
 		cli, _ = dialAndBootstrapClient(t, address, testUsername, testPassword, testBucket)
 	}
 
 	t.Cleanup(func() {
-		cli.Close()
+		err := cli.Close()
+		require.NoError(t, err)
 	})
 
 	return cli


### PR DESCRIPTION
Reasoning is in the comments of the associated ticket