### PR TITLE
ING-754: Fix exponential-backoff retry handling.

### DIFF
--- a/retrymanager_default.go
+++ b/retrymanager_default.go
@@ -13,7 +13,7 @@ type RetryManagerDefault struct {
 
 func NewRetryManagerDefault() *RetryManagerDefault {
 	return &RetryManagerDefault{
-		calc: ExponentialBackoff(0, 500*time.Millisecond, 1),
+		calc: ExponentialBackoff(10*time.Millisecond, 500*time.Millisecond, 2),
 	}
 }
 


### PR DESCRIPTION
Previously we would retry operations every 1ms forever, now it will retry after 10ms, 20ms, 40ms, 80ms, etc...