### PR TITLE
ING-689: Check for goroutine leaks at the end of integration tests

### DIFF
--- a/agent_int_test.go
+++ b/agent_int_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/couchbase/gocbcorex"
 	"github.com/couchbase/gocbcorex/cbmgmtx"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/couchbase/gocbcorex/testutilsint"
@@ -75,6 +76,8 @@ func TestAgentBasic(t *testing.T) {
 
 	err = agent.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentBasicTLSInsecure(t *testing.T) {
@@ -114,6 +117,8 @@ func TestAgentBasicTLSInsecure(t *testing.T) {
 
 	err = agent.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentReconfigureNoTLSToTLS(t *testing.T) {
@@ -154,6 +159,8 @@ func TestAgentReconfigureNoTLSToTLS(t *testing.T) {
 
 	err = agent.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentReconfigureNoBucketToBucket(t *testing.T) {
@@ -191,6 +198,8 @@ func TestAgentReconfigureNoBucketToBucket(t *testing.T) {
 
 	err = agent.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentBadCollection(t *testing.T) {
@@ -214,6 +223,8 @@ func TestAgentBadCollection(t *testing.T) {
 
 	err = agent.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentCrudCompress(t *testing.T) {
@@ -354,6 +365,7 @@ func TestAgentCrudCompress(t *testing.T) {
 			assert.Equal(tt, test.Expect, get2.Value)
 		})
 	}
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentCrudDecompress(t *testing.T) {
@@ -444,6 +456,7 @@ func TestAgentCrudDecompress(t *testing.T) {
 
 		})
 	}
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentWatchConfig(t *testing.T) {
@@ -453,6 +466,8 @@ func TestAgentWatchConfig(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(5*time.Second))
@@ -477,6 +492,7 @@ func TestAgentBucketNotExist(t *testing.T) {
 		err = agent.Close()
 		require.NoError(t, err)
 	}
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestAgentConnectAfterCreateBucket(t *testing.T) {
@@ -490,6 +506,7 @@ func TestAgentConnectAfterCreateBucket(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	bucketName := "testBucket-" + uuid.NewString()[:6]
@@ -597,5 +614,5 @@ func BenchmarkBasicGet(b *testing.B) {
 		}
 	}
 	b.ReportAllocs()
-
+	require.False(b, leakcheck.ReportLeakedGoroutines())
 }

--- a/agent_ops_int_test.go
+++ b/agent_ops_int_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcorex"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/google/uuid"
@@ -38,6 +39,7 @@ func TestAgentDelete(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	docKey := uuid.NewString()
@@ -91,6 +93,7 @@ func TestAgentDoesNotRetryMemdxInvalidArgs(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)

--- a/agent_ops_rangescan_int_test.go
+++ b/agent_ops_rangescan_int_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/couchbase/gocbcorex"
 	"github.com/couchbase/gocbcorex/cbmgmtx"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/stretchr/testify/assert"
@@ -24,6 +25,7 @@ func TestRangeScanRangeLargeValues(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	size := 8192 * 2
@@ -77,6 +79,7 @@ func TestRangeScanRangeSmallValues(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	value := []byte(`{"barry": "sheen"}`)
@@ -127,6 +130,7 @@ func TestRangeScanRangeKeysOnly(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	value := "value"
@@ -174,6 +178,7 @@ func TestRangeScanSamplingKeysOnly(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	scopeName := "sample" + uuid.NewString()[:6]
@@ -247,6 +252,7 @@ func TestRangeScanRangeCancellation(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	value := "value"
@@ -281,6 +287,7 @@ func TestRangeScanRangeContinueClosedClient(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	value := "value"
@@ -318,6 +325,7 @@ func TestRangeScanRangeCancelClosedClient(t *testing.T) {
 	t.Cleanup(func() {
 		err := agent.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	value := "value"

--- a/agentmanager_int_test.go
+++ b/agentmanager_int_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/couchbase/gocbcorex"
 	"github.com/couchbase/gocbcorex/cbmgmtx"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 
 	"github.com/stretchr/testify/assert"
 
@@ -87,6 +88,8 @@ func TestOnDemandAgentManagerClose(t *testing.T) {
 
 	_, err = mgr.GetBucketAgent(context.Background(), testutilsint.TestOpts.BucketName)
 	assert.Error(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestBucketsTrackingAgentManagerClose(t *testing.T) {
@@ -122,6 +125,8 @@ func TestBucketsTrackingAgentManagerClose(t *testing.T) {
 
 	_, err = mgr.GetBucketAgent(context.Background(), testutilsint.TestOpts.BucketName)
 	assert.Error(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestBucketsTrackingAgentManagerBucketNotExist(t *testing.T) {
@@ -145,4 +150,6 @@ func TestBucketsTrackingAgentManagerBucketNotExist(t *testing.T) {
 
 	err = mgr.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }

--- a/bucketswatcher_http_int_test.go
+++ b/bucketswatcher_http_int_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/couchbase/gocbcorex"
 	"github.com/couchbase/gocbcorex/cbmgmtx"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 
 	"github.com/stretchr/testify/assert"
 
@@ -69,7 +70,7 @@ func TestBucketsWatcherHttp(t *testing.T) {
 
 		// There should only have been 1 request, the stream open.
 		assert.Equal(tt, 1, tripper.NumReqs())
-
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	t.Run("FetchesUnknownBuckets", func(tt *testing.T) {
@@ -89,6 +90,7 @@ func TestBucketsWatcherHttp(t *testing.T) {
 
 		// There should only have been 1 request.
 		assert.Equal(tt, 1, tripper.NumReqs())
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	t.Run("OnlyFetchesABucketOnce", func(tt *testing.T) {
@@ -113,6 +115,7 @@ func TestBucketsWatcherHttp(t *testing.T) {
 
 		// There should only have been 1 request.
 		assert.Equal(tt, 1, tripper.NumReqs())
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	t.Run("OnlyFetchesABucketOnceWithConcurrency", func(tt *testing.T) {
@@ -145,6 +148,7 @@ func TestBucketsWatcherHttp(t *testing.T) {
 
 		// There should only have been 1 request.
 		assert.Equal(tt, 1, tripper.NumReqs())
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	t.Run("UnknownBucketWithConcurrencyAfterFirstRequestIssued", func(tt *testing.T) {
@@ -186,5 +190,6 @@ func TestBucketsWatcherHttp(t *testing.T) {
 
 		// There should have been 2 requests, as we issued the second GetAgent whilst the first was already in flight.
 		assert.Equal(tt, 2, tripper.NumReqs())
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 }

--- a/kvclient_int_test.go
+++ b/kvclient_int_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/gocbcorex"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/google/uuid"
@@ -60,6 +61,7 @@ func TestKvClientReconfigureBucket(t *testing.T) {
 
 	err = cli.Close()
 	require.NoError(t, err)
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestKvClientCloseAfterReconfigure(t *testing.T) {
@@ -93,4 +95,5 @@ func TestKvClientCloseAfterReconfigure(t *testing.T) {
 
 	err = cli.Close()
 	require.NoError(t, err)
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }

--- a/kvclientmanager_int_test.go
+++ b/kvclientmanager_int_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/couchbase/gocbcorex"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -55,6 +56,8 @@ func TestClientManagerClose(t *testing.T) {
 	// Check that getting a client fails after close.
 	_, err = mgr.GetClient(context.Background(), endpointName)
 	require.Error(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestClientManagerCloseAfterReconfigure(t *testing.T) {
@@ -116,4 +119,6 @@ func TestClientManagerCloseAfterReconfigure(t *testing.T) {
 	// Check that getting a client fails after close.
 	_, err = mgr.GetClient(context.Background(), endpointName)
 	require.Error(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }

--- a/kvclientpool_int_test.go
+++ b/kvclientpool_int_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/couchbase/gocbcorex"
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -39,6 +40,7 @@ func TestKvClientPoolClose(t *testing.T) {
 	t.Cleanup(func() {
 		err := pool.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	// Check that we've connected at least 1 client
@@ -96,6 +98,8 @@ func TestKvClientPoolCloseAfterReconfigure(t *testing.T) {
 
 	err = pool.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }
 
 func TestKvClientPoolHandleClientClose(t *testing.T) {
@@ -143,4 +147,6 @@ func TestKvClientPoolHandleClientClose(t *testing.T) {
 
 	err = pool.Close()
 	require.NoError(t, err)
+
+	require.False(t, leakcheck.ReportLeakedGoroutines())
 }

--- a/memdx/harness_int_test.go
+++ b/memdx/harness_int_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/couchbase/gocbcorex/contrib/leakcheck"
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/stretchr/testify/require"
@@ -46,6 +47,7 @@ func createTestClient(t *testing.T) *memdx.Client {
 	t.Cleanup(func() {
 		err := cli.Close()
 		require.NoError(t, err)
+		require.False(t, leakcheck.ReportLeakedGoroutines())
 	})
 
 	return cli


### PR DESCRIPTION
After a few attempts I couldn't identify where the leak in the ticket came from. So have added more granular checking for leaks at the end of tests which could have caused this.