### PR TITLE
ING-523: Improve GetAllReplicas handling

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Install cbdinocluster
         run: |
           mkdir -p "$HOME/bin"
-          wget -nv -O $HOME/bin/cbdinocluster https://github.com/couchbaselabs/cbdinocluster/releases/download/v0.0.22/cbdinocluster-linux
+          wget -nv -O $HOME/bin/cbdinocluster https://github.com/couchbaselabs/cbdinocluster/releases/download/v0.0.41/cbdinocluster-linux-amd64
           chmod +x $HOME/bin/cbdinocluster
           echo "$HOME/bin" >> $GITHUB_PATH
       - name: Initialize cbdinocluster
@@ -41,7 +41,7 @@ jobs:
               kv-memory: 512
         run: |
           CBDC_ID=$(cbdinocluster -v alloc --def="${CLUSTERCONFIG}")
-          cbdinocluster -v buckets add ${CBDC_ID} default --ram-quota-mb=100 --flush-enabled=true
+          cbdinocluster -v buckets add ${CBDC_ID} default --ram-quota-mb=100 --flush-enabled=true --num-replicas=2
           cbdinocluster -v collections add ${CBDC_ID} default _default test
           CBDC_CONNSTR=$(cbdinocluster -v connstr $CBDC_ID)
           echo "CBDC_ID=$CBDC_ID" >> "$GITHUB_ENV"

--- a/agent_ops.go
+++ b/agent_ops.go
@@ -22,6 +22,10 @@ func (agent *Agent) GetReplica(ctx context.Context, opts *GetReplicaOptions) (*G
 	return agent.crud.GetReplica(ctx, opts)
 }
 
+func (agent *Agent) GetAllReplicas(ctx context.Context, opts *GetAllReplicasOptions) (GetAllReplicaStream, error) {
+	return agent.crud.GetAllReplicas(ctx, opts)
+}
+
 func (agent *Agent) Delete(ctx context.Context, opts *DeleteOptions) (*DeleteResult, error) {
 	return agent.crud.Delete(ctx, opts)
 }

--- a/crud_int_test.go
+++ b/crud_int_test.go
@@ -1,0 +1,93 @@
+package gocbcorex_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/couchbase/gocbcorex"
+	"github.com/couchbase/gocbcorex/testutilsint"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const NUM_REPLICAS = 2
+
+func TestGetAllReplicasDino(t *testing.T) {
+	testutilsint.SkipIfNoDinoCluster(t)
+
+	opts := CreateDefaultAgentOptions()
+	agent, err := gocbcorex.CreateAgent(context.Background(), opts)
+	defer func() {
+		err := agent.Close()
+		require.NoError(t, err)
+	}()
+
+	require.NoError(t, err)
+
+	docKey := uuid.NewString()
+	upsertRes, err := agent.Upsert(context.Background(), &gocbcorex.UpsertOptions{
+		Key:            []byte(docKey),
+		ScopeName:      "",
+		CollectionName: "",
+		Value:          []byte(`{"foo": "bar"}`),
+	})
+	require.NoError(t, err)
+	assert.NotZero(t, upsertRes.Cas)
+
+	require.Eventually(t, func() bool {
+		count := replicaCount(t, agent, docKey)
+		return count == NUM_REPLICAS+1
+	}, time.Second*15, time.Second*1)
+
+	nodes := testutilsint.GetTestNodes(t)
+	nonOrchestrators := nodes.Select(func(node *testutilsint.NodeTarget) bool {
+		return !node.IsOrchestrator
+	})
+
+	blocked := 0
+	dino := testutilsint.StartDinoTesting(t, true)
+	for _, node := range nonOrchestrators {
+		dino.BlockAllTraffic(node.Hostname)
+		blocked += 1
+
+		require.Eventually(t, func() bool {
+			count := replicaCount(t, agent, docKey)
+			return count == NUM_REPLICAS+1-blocked
+		}, time.Second*15, time.Second*1)
+	}
+
+	for _, node := range nonOrchestrators {
+		dino.AllowTraffic(node.Hostname)
+		blocked -= 1
+
+		require.Eventually(t, func() bool {
+			count := replicaCount(t, agent, docKey)
+			return count == NUM_REPLICAS+1-blocked
+		}, time.Second*15, time.Second*1)
+	}
+}
+
+func replicaCount(t *testing.T, agent *gocbcorex.Agent, docKey string) int {
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
+	defer cancel()
+
+	stream, err := agent.GetAllReplicas(ctx, &gocbcorex.GetAllReplicasOptions{
+		Key:            []byte(docKey),
+		BucketName:     "default",
+		ScopeName:      "",
+		CollectionName: "",
+	})
+	require.NoError(t, err)
+
+	result, err := stream.Next()
+	count := 0
+	for result != nil {
+		require.NoError(t, err)
+		require.Equal(t, result.Value, []byte(`{"foo": "bar"}`))
+		count += 1
+		result, err = stream.Next()
+	}
+	return count
+}

--- a/docs/REPLICA_READ.md
+++ b/docs/REPLICA_READ.md
@@ -1,0 +1,23 @@
+The overarching behaviour of GetAllReplicas, is that we will attempt to get every possible replica until all replicas are returned
+or the operation times out. At most NUM_REPLICAS + 1 replicas can be returned, all the replicas plus the master copy, however there
+is no guarantee about the minimum number of replicas that will be returned, nor that they will include the master. However the
+algorithm will return at most one document from each node.
+
+A motivator for the re-design was to prevent duplicate reads of replicas being returned. This used to be possible, since the routing
+logic uses replicaIds to find the vbuckets containing particular replicas. This can be problematic when a rebalance occurs mid
+GetAllReplicas since replicaIds can be changed during a rebalance, so we could read replica 1, a rebalance occur, then get routed to
+the same replica when we try to read replica 2. The new algorithm solves this issue by keeping track of which nodes we have recieved
+replicas from and ignoring any duplicate reads.
+
+In the new design we start a go routine for each possible replica, to fetch them in paralell. Something apparently unusual
+is that a thread is not terminated when a replica is returned from it. This is because each thread is tied to a specific replicaId,
+and as mentioned these replicaIds can be associated with docs on different nodes if a rebalance occurs. For example the thread reading
+the replica with replicaId 1 could fetch the replica, then a rebalance occurs. Now imaagine the replica with replicaId 1 is now on
+a node from which we have yet to read. If we had terminated the replicaId 1 thread afer the first successful read we would have
+no way of reading the moved replica, so we keep every thread alive and polling it's associated replica to see if it has moved.
+
+Errors can be returned by a call to GetAllReplicas in two ways. Firstly GetAllReplicas can directly return an error when some
+state has occured under which none of the documents are able to be fetched, e.g the collection ID cannot be found. Then there are
+errors that can be streamed back from each of the individual replica reads, this allows the user to decide how to handle the error
+given their use case for GetAllReplicas. If they are using it to get any replica, they may ignore and continue, however if they wanted
+a quorum then a single error may be fatal, but we want the user to be able to make this decision.

--- a/errors.go
+++ b/errors.go
@@ -13,6 +13,7 @@ var (
 	ErrVbucketMapOutdated         = errors.New("the vbucket map is out of date")
 	ErrCollectionManifestOutdated = errors.New("the collection manifest is out of date")
 	ErrServiceNotAvailable        = errors.New("service is not available")
+	ErrRepeatedReplicaRead        = errors.New("a replica has already been returned from this node")
 )
 
 type placeholderError struct {

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	go.opentelemetry.io/otel v1.24.0
 	go.opentelemetry.io/otel/sdk v1.24.0
 	go.opentelemetry.io/otel/trace v1.24.0
+	go.uber.org/atomic v1.7.0
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20230131160201-f062dba9d201
 	golang.org/x/mod v0.14.0
@@ -23,7 +24,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	go.opentelemetry.io/otel/metric v1.24.0 // indirect
-	go.uber.org/atomic v1.7.0 // indirect
 	go.uber.org/multierr v1.6.0 // indirect
 	golang.org/x/sys v0.17.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/mock_vbucketrouter_test.go
+++ b/mock_vbucketrouter_test.go
@@ -103,6 +103,10 @@ func (mock *VbucketRouterMock) DispatchByKeyCalls() []struct {
 	return calls
 }
 
+func (mock *VbucketRouterMock) NumReplicas() (int, error) {
+	return 0, nil
+}
+
 // DispatchToVbucket calls DispatchToVbucketFunc.
 func (mock *VbucketRouterMock) DispatchToVbucket(vbID uint16) (string, error) {
 	if mock.DispatchToVbucketFunc == nil {

--- a/retrymanager_getallreplicas.go
+++ b/retrymanager_getallreplicas.go
@@ -1,0 +1,57 @@
+package gocbcorex
+
+import (
+	"errors"
+	"time"
+
+	"github.com/couchbase/gocbcorex/memdx"
+)
+
+type RetryManagerGetAllReplicas struct {
+	calc BackoffCalculator
+}
+
+func NewRetryManagerGetAllReplicas() *RetryManagerGetAllReplicas {
+	return &RetryManagerGetAllReplicas{
+		calc: ExponentialBackoff(10*time.Millisecond, 500*time.Millisecond, 2),
+	}
+}
+
+func (m *RetryManagerGetAllReplicas) NewRetryController() RetryController {
+	return &retryControllerGetAllReplicas{
+		parent: m,
+	}
+}
+
+type retryControllerGetAllReplicas struct {
+	parent     *RetryManagerGetAllReplicas
+	retryCount uint32
+}
+
+func (rc *retryControllerGetAllReplicas) isRetriableError(err error) bool {
+	// Implement the default classification of retriable errors...
+	return errors.Is(err, memdx.ErrTmpFail) ||
+		errors.Is(err, memdx.ErrConfigNotSet) ||
+		errors.Is(err, memdx.ErrSyncWriteInProgress) ||
+		errors.Is(err, memdx.ErrSyncWriteReCommitInProgress) ||
+		errors.Is(err, ErrVbucketMapOutdated) ||
+		errors.Is(err, ErrCollectionManifestOutdated) ||
+		errors.Is(err, ErrNoServerAssigned) ||
+		errors.Is(err, ErrRepeatedReplicaRead)
+}
+
+func (rc *retryControllerGetAllReplicas) ShouldRetry(err error) (time.Duration, bool) {
+	if !rc.isRetriableError(err) {
+		return 0, false
+	}
+
+	calc := rc.parent.calc
+
+	// calculate the retry time for this attempt
+	retryTime := calc(rc.retryCount)
+
+	// increment the retry count
+	rc.retryCount++
+
+	return retryTime, true
+}

--- a/vbucketrouter.go
+++ b/vbucketrouter.go
@@ -20,6 +20,7 @@ type VbucketRouter interface {
 	UpdateRoutingInfo(*VbucketRoutingInfo)
 	DispatchByKey(key []byte, vbServerIdx uint32) (string, uint16, error)
 	DispatchToVbucket(vbID uint16) (string, error)
+	NumReplicas() (int, error)
 }
 
 type VbucketRoutingInfo struct {
@@ -52,6 +53,15 @@ func NewVbucketRouter(opts *VbucketRouterOptions) *vbucketRouter {
 
 func (vbd *vbucketRouter) UpdateRoutingInfo(info *VbucketRoutingInfo) {
 	vbd.routingInfo.Store(info)
+}
+
+func (vbd *vbucketRouter) NumReplicas() (int, error) {
+	info, err := vbd.getRoutingInfo()
+	if err != nil {
+		return 0, err
+	}
+
+	return info.VbMap.NumReplicas(), nil
 }
 
 func (vbd *vbucketRouter) getRoutingInfo() (*VbucketRoutingInfo, error) {


### PR DESCRIPTION
The logic here starts a thread for each replica that should exist according to NUM_REPLICAS. The overall GetAllReplicas operation is complete when NUM_REPLICAS + 1 docs have been returned, or it hits the timeout. The individual threads will run indefinitely until these points, even if the thread has returned a document. This is because the individual requests are routed based on the replica ID, which can be routed to a different node if there is a rebalance during the GetAllReplicas.