### PR TITLE
ING-942: Added read buffering and enable NAGLE in memdx.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.55
+          version: v1.61
           args: --timeout=3m
           skip-pkg-cache: true
           skip-build-cache: true

--- a/agent.go
+++ b/agent.go
@@ -68,6 +68,11 @@ func CreateAgent(ctx context.Context, opts AgentOptions) (*Agent, error) {
 	clientName := fmt.Sprintf("gocbcorex/%s", buildVersion)
 	srcHTTPAddrs := makeSrcHTTPAddrs(opts.SeedConfig.HTTPAddrs, opts.TLSConfig)
 
+	connectionPoolSize := opts.IoConfig.ConnectionPoolSize
+	if connectionPoolSize == 0 {
+		connectionPoolSize = 1
+	}
+
 	// Default values.
 	compressionMinSize := 32
 	compressionMinRatio := 0.83
@@ -145,7 +150,7 @@ func CreateAgent(ctx context.Context, opts AgentOptions) (*Agent, error) {
 			bucket:             opts.BucketName,
 			tlsConfig:          opts.TLSConfig,
 			authenticator:      opts.Authenticator,
-			numPoolConnections: 1,
+			numPoolConnections: connectionPoolSize,
 			latestConfig:       bootstrapConfig,
 			httpTransport:      httpTransport,
 		},

--- a/agent_options.go
+++ b/agent_options.go
@@ -27,6 +27,7 @@ type AgentOptions struct {
 	SeedConfig SeedConfig
 
 	CompressionConfig CompressionConfig
+	IoConfig          IoConfig
 
 	ConfigPollerConfig ConfigPollerConfig
 
@@ -80,6 +81,16 @@ func (c CompressionConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	enc.AddInt("min-size", c.MinSize)
 	enc.AddFloat64("min-ratio", c.MinRatio)
 
+	return nil
+}
+
+// IoConfig specifies options for controlling io setup.
+type IoConfig struct {
+	ConnectionPoolSize uint
+}
+
+func (c IoConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddUint("connection-pool-size", c.ConnectionPoolSize)
 	return nil
 }
 


### PR DESCRIPTION
Read buffering significantly reduces the costs of our reads by reducing the number of syscalls that need to be made.  Enabling NAGLE improves network efficiency, though this should ultimately be performed from inside gocbcorex at some point.  I saw better performance than enabling NAGLE by having a queue of packets to send and a goroutine which used a write buffer alongside deciding whether to flush it based on there being other data to write in the queue.