### PR TITLE
ING-959: Refactored hostname handling when parsing configs.

### DIFF
--- a/contrib/cbconfig/parse.go
+++ b/contrib/cbconfig/parse.go
@@ -1,0 +1,16 @@
+package cbconfig
+
+import (
+	"bytes"
+	"encoding/json"
+)
+
+func ParseTerseConfig(config []byte, sourceHostname string) (*TerseConfigJson, error) {
+	config = bytes.ReplaceAll(config, []byte("$HOST"), []byte(sourceHostname))
+	var configOut *TerseConfigJson
+	err := json.Unmarshal(config, &configOut)
+	if err != nil {
+		return nil, err
+	}
+	return configOut, nil
+}

--- a/crud_test.go
+++ b/crud_test.go
@@ -3,6 +3,7 @@ package gocbcorex
 import (
 	"context"
 	"fmt"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,7 +40,11 @@ func TestSimpleCrudCollectionMapOutdatedRetries(t *testing.T) {
 	}
 	nkcp := &KvClientManagerMock{
 		GetClientFunc: func(ctx context.Context, endpoint string) (KvClient, error) {
-			return &KvClientMock{}, nil
+			return &KvClientMock{
+				RemoteHostnameFunc: func() string { return "hostname" },
+				RemoteAddrFunc:     func() net.Addr { return &net.TCPAddr{} },
+				LocalAddrFunc:      func() net.Addr { return &net.TCPAddr{} },
+			}, nil
 		},
 	}
 

--- a/generate-mocks.go
+++ b/generate-mocks.go
@@ -1,6 +1,6 @@
 //go:generate moq -out mock_collectionresolver_test.go . CollectionResolver
 //go:generate moq -out mock_vbucketrouter_test.go . VbucketRouter
-//go:generate moq -out mock_kvclient_test.go . KvClient MemdxDispatcherCloser
+//go:generate moq -out mock_kvclient_test.go . KvClient MemdxClient
 //go:generate moq -out mock_kvclientpool_test.go . KvClientPool
 //go:generate moq -out mock_kvclientmanager_test.go . KvClientManager
 //go:generate moq -out mock_retrymanager_test.go . RetryManager RetryController

--- a/kvclient_ops.go
+++ b/kvclient_ops.go
@@ -68,8 +68,8 @@ func kvClient_SimpleCall[Encoder any, ReqT memdx.OpRequest, RespT memdx.OpRespon
 	req ReqT,
 ) (RespT, error) {
 	bucketName := c.SelectedBucket()
-	localHost, localPort := c.LocalHostPort()
-	_, remoteHost, remotePort := c.RemoteHostPort()
+	localHost, localPort := hostPortFromNetAddr(c.LocalAddr())
+	remoteHost, remotePort := hostPortFromNetAddr(c.RemoteAddr())
 
 	stime := time.Now()
 

--- a/kvclient_test.go
+++ b/kvclient_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/tls"
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/couchbase/gocbcorex/memdx"
@@ -23,11 +24,7 @@ func (mpo memdxPendingOpMock) Cancel(err error) {
 func TestKvClientReconfigureBucketOverExistingBucket(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
-		DispatchFunc:   nil,
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
-	}
+	memdxCli := &MemdxClientMock{}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
 		Address: "endpoint1",
@@ -38,7 +35,7 @@ func TestKvClientReconfigureBucketOverExistingBucket(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -58,11 +55,7 @@ func TestKvClientReconfigureBucketOverExistingBucket(t *testing.T) {
 func TestKvClientReconfigureTLSConfig(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
-		DispatchFunc:   nil,
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
-	}
+	memdxCli := &MemdxClientMock{}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
 		Address: "endpoint1",
@@ -73,7 +66,7 @@ func TestKvClientReconfigureTLSConfig(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -93,11 +86,7 @@ func TestKvClientReconfigureTLSConfig(t *testing.T) {
 func TestKvClientReconfigureUsername(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
-		DispatchFunc:   nil,
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
-	}
+	memdxCli := &MemdxClientMock{}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
 		Address: "endpoint1",
@@ -108,7 +97,7 @@ func TestKvClientReconfigureUsername(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -128,11 +117,7 @@ func TestKvClientReconfigureUsername(t *testing.T) {
 func TestKvClientReconfigurePassword(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
-		DispatchFunc:   nil,
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
-	}
+	memdxCli := &MemdxClientMock{}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
 		Address: "endpoint1",
@@ -143,7 +128,7 @@ func TestKvClientReconfigurePassword(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -163,11 +148,7 @@ func TestKvClientReconfigurePassword(t *testing.T) {
 func TestKvClientReconfigureAddress(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
-		DispatchFunc:   nil,
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
-	}
+	memdxCli := &MemdxClientMock{}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
 		Address: "endpoint1",
@@ -178,7 +159,7 @@ func TestKvClientReconfigureAddress(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -199,12 +180,10 @@ func TestKvClientReconfigureAddress(t *testing.T) {
 func TestKvClientOrphanResponseHandler(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
+	memdxCli := &MemdxClientMock{
 		DispatchFunc: func(packet *memdx.Packet, dispatchCallback memdx.DispatchCallback) (memdx.PendingOp, error) {
 			return memdxPendingOpMock{}, nil
 		},
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
 	}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
@@ -216,7 +195,7 @@ func TestKvClientOrphanResponseHandler(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -228,12 +207,10 @@ func TestKvClientOrphanResponseHandler(t *testing.T) {
 func TestKvClientConnCloseHandlerDefault(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
+	memdxCli := &MemdxClientMock{
 		DispatchFunc: func(packet *memdx.Packet, dispatchCallback memdx.DispatchCallback) (memdx.PendingOp, error) {
 			return memdxPendingOpMock{}, nil
 		},
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
 	}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
@@ -245,7 +222,7 @@ func TestKvClientConnCloseHandlerDefault(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -258,12 +235,10 @@ func TestKvClientConnCloseHandlerDefault(t *testing.T) {
 func TestKvClientConnCloseHandlerCallsUpstream(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
+	memdxCli := &MemdxClientMock{
 		DispatchFunc: func(packet *memdx.Packet, dispatchCallback memdx.DispatchCallback) (memdx.PendingOp, error) {
 			return memdxPendingOpMock{}, nil
 		},
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
 	}
 
 	var closedCli KvClient
@@ -277,7 +252,7 @@ func TestKvClientConnCloseHandlerCallsUpstream(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 		CloseHandler: func(client KvClient, err error) {
@@ -296,12 +271,12 @@ func TestKvClientConnCloseHandlerCallsUpstream(t *testing.T) {
 func TestKvClientWrapsDispatchError(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
+	memdxCli := &MemdxClientMock{
 		DispatchFunc: func(packet *memdx.Packet, dispatchCallback memdx.DispatchCallback) (memdx.PendingOp, error) {
 			return nil, memdx.ErrDispatch
 		},
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
+		LocalAddrFunc:  func() net.Addr { return &net.TCPAddr{} },
+		RemoteAddrFunc: func() net.Addr { return &net.TCPAddr{} },
 	}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
@@ -313,7 +288,7 @@ func TestKvClientWrapsDispatchError(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})
@@ -329,12 +304,12 @@ func TestKvClientWrapsDispatchError(t *testing.T) {
 func TestKvClientDoesNotWrapNonDispatchError(t *testing.T) {
 	logger, _ := zap.NewDevelopment()
 
-	memdxCli := &MemdxDispatcherCloserMock{
+	memdxCli := &MemdxClientMock{
 		DispatchFunc: func(packet *memdx.Packet, dispatchCallback memdx.DispatchCallback) (memdx.PendingOp, error) {
 			return nil, memdx.ErrProtocol
 		},
-		RemoteAddrFunc: func() string { return "remote:1" },
-		LocalAddrFunc:  func() string { return "local:2" },
+		LocalAddrFunc:  func() net.Addr { return &net.TCPAddr{} },
+		RemoteAddrFunc: func() net.Addr { return &net.TCPAddr{} },
 	}
 
 	cli, err := NewKvClient(context.Background(), &KvClientConfig{
@@ -346,7 +321,7 @@ func TestKvClientDoesNotWrapNonDispatchError(t *testing.T) {
 		DisableErrorMap:        true,
 	}, &KvClientOptions{
 		Logger: logger,
-		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxDispatcherCloser {
+		NewMemdxClient: func(opts *memdx.ClientOptions) MemdxClient {
 			return memdxCli
 		},
 	})

--- a/kvclientmanager_test.go
+++ b/kvclientmanager_test.go
@@ -3,6 +3,7 @@ package gocbcorex
 import (
 	"context"
 	"errors"
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -602,7 +603,11 @@ func TestKvClientManagerPoolReturnError(t *testing.T) {
 
 func TestOrchestrateMemdClient(t *testing.T) {
 	ep := "endpoint1"
-	expectedClient := &KvClientMock{}
+	expectedClient := &KvClientMock{
+		RemoteHostnameFunc: func() string { return "hostname" },
+		RemoteAddrFunc:     func() net.Addr { return &net.TCPAddr{} },
+		LocalAddrFunc:      func() net.Addr { return &net.TCPAddr{} },
+	}
 	mgr := &KvClientManagerMock{
 		GetClientFunc: func(ctx context.Context, endpoint string) (KvClient, error) {
 			assert.Equal(t, ep, endpoint)
@@ -622,7 +627,11 @@ func TestOrchestrateMemdClient(t *testing.T) {
 }
 
 func TestOrchestrateRandomMemdClient(t *testing.T) {
-	expectedClient := &KvClientMock{}
+	expectedClient := &KvClientMock{
+		RemoteHostnameFunc: func() string { return "hostname" },
+		RemoteAddrFunc:     func() net.Addr { return &net.TCPAddr{} },
+		LocalAddrFunc:      func() net.Addr { return &net.TCPAddr{} },
+	}
 	mgr := &KvClientManagerMock{
 		GetRandomClientFunc: func(ctx context.Context) (KvClient, error) {
 			return expectedClient, nil
@@ -689,7 +698,11 @@ func TestOrchestrateMemdClientGetReturnError(t *testing.T) {
 }
 
 func TestOrchestrateMemdCallbackReturnError(t *testing.T) {
-	client := &KvClientMock{}
+	client := &KvClientMock{
+		RemoteHostnameFunc: func() string { return "hostname" },
+		RemoteAddrFunc:     func() net.Addr { return &net.TCPAddr{} },
+		LocalAddrFunc:      func() net.Addr { return &net.TCPAddr{} },
+	}
 	expectedErr := errors.New("somesortoferror")
 
 	mgr := &KvClientManagerMock{
@@ -730,13 +743,17 @@ func TestOrchestrateMemdCallbackReturnError(t *testing.T) {
 			err := test.Fn(func(client KvClient) (int, error) {
 				return 0, expectedErr
 			})
-			assert.Equal(tt, expectedErr, err)
+			assert.ErrorIs(tt, err, expectedErr)
 		})
 	}
 }
 
 func TestOrchestrateRandomMemdCallbackReturnDispatchError(t *testing.T) {
-	expectedClient := &KvClientMock{}
+	expectedClient := &KvClientMock{
+		RemoteHostnameFunc: func() string { return "hostname" },
+		RemoteAddrFunc:     func() net.Addr { return &net.TCPAddr{} },
+		LocalAddrFunc:      func() net.Addr { return &net.TCPAddr{} },
+	}
 	var shutdowns int
 	mgr := &KvClientManagerMock{
 		GetRandomClientFunc: func(ctx context.Context) (KvClient, error) {
@@ -768,7 +785,11 @@ func TestOrchestrateRandomMemdCallbackReturnDispatchError(t *testing.T) {
 }
 
 func TestOrchestrateMemdCallbackReturnDispatchError(t *testing.T) {
-	expectedClient := &KvClientMock{}
+	expectedClient := &KvClientMock{
+		RemoteHostnameFunc: func() string { return "hostname" },
+		RemoteAddrFunc:     func() net.Addr { return &net.TCPAddr{} },
+		LocalAddrFunc:      func() net.Addr { return &net.TCPAddr{} },
+	}
 	ep := "endpoint1"
 	var shutdowns int
 	mgr := &KvClientManagerMock{

--- a/kvclientpool.go
+++ b/kvclientpool.go
@@ -3,7 +3,6 @@ package gocbcorex
 import (
 	"context"
 	"errors"
-	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -61,6 +60,7 @@ type kvClientPool struct {
 
 	lock           sync.Mutex
 	config         KvClientPoolConfig
+	poolName       string
 	connectErr     error
 	connectErrTime time.Time
 	closeSig       chan struct{}
@@ -121,9 +121,12 @@ func NewKvClientPool(config *KvClientPoolConfig, opts *KvClientPoolOptions) (*kv
 		logger.Warn("failed to create connection failure metric")
 	}
 
+	poolName := config.ClientConfig.Address + "/" + config.ClientConfig.SelectedBucket
+
 	p := &kvClientPool{
 		logger:                   logger,
 		config:                   *config,
+		poolName:                 poolName,
 		connectTimeout:           connectTimeout,
 		connectErrThrottlePeriod: connectErrThrottlePeriod,
 
@@ -238,6 +241,7 @@ func (p *kvClientPool) startNewClientLocked() <-chan struct{} {
 	}
 	p.addPendingClientLocked(pendingClient)
 
+	poolName := p.poolName
 	clientConfig := p.config.ClientConfig
 
 	// create the goroutine to actually create the client
@@ -280,7 +284,6 @@ func (p *kvClientPool) startNewClientLocked() <-chan struct{} {
 		connDTime := connETime.Sub(connStime)
 		connDTimeSecs := float64(connDTime) / float64(time.Second)
 
-		poolName := clientConfig.Address + "/" + clientConfig.SelectedBucket
 		if err != nil {
 			p.connFailureMetric.Add(context.Background(), 1, metric.WithAttributes(
 				semconv.DBSystemCouchbase,
@@ -422,16 +425,13 @@ func (p *kvClientPool) rebuildActiveClientsLocked() {
 }
 
 func (p *kvClientPool) handleClientClosed(client KvClient, err error) {
-	host, _, port := client.RemoteHostPort()
-	poolName := fmt.Sprintf("%s:%d", host, port)
+	p.lock.Lock()
+	defer p.lock.Unlock()
 
 	p.connCountMetric.Record(context.Background(), -1, metric.WithAttributes(
 		semconv.DBSystemCouchbase,
-		semconv.DBClientConnectionsPoolName(poolName),
+		semconv.DBClientConnectionsPoolName(p.poolName),
 	))
-
-	p.lock.Lock()
-	defer p.lock.Unlock()
 
 	if !p.removeCurrentClientLocked(client) {
 		// If the client is no longer current anyways, we have nothing to do...
@@ -453,11 +453,11 @@ func (p *kvClientPool) Reconfigure(config *KvClientPoolConfig, cb func(error)) e
 
 	p.logger.Debug("reconfiguring")
 
-	oldConfig := p.config.ClientConfig
-	oldPoolName := oldConfig.Address + "/" + oldConfig.SelectedBucket
-	newPoolName := oldConfig.Address + "/" + config.ClientConfig.SelectedBucket
+	oldPoolName := p.poolName
+	newPoolName := config.ClientConfig.Address + "/" + config.ClientConfig.SelectedBucket
 
 	p.config = *config
+	p.poolName = newPoolName
 
 	numClientsReconfiguring := int64(len(p.currentClients))
 	markClientReconfigureDone := func() {
@@ -473,7 +473,6 @@ func (p *kvClientPool) Reconfigure(config *KvClientPoolConfig, cb func(error)) e
 
 	clientsToReconfigure := make([]KvClient, len(p.currentClients))
 	copy(clientsToReconfigure, p.currentClients)
-	numReconfigured := 0
 	for _, client := range clientsToReconfigure {
 		client := client
 
@@ -505,23 +504,23 @@ func (p *kvClientPool) Reconfigure(config *KvClientPoolConfig, cb func(error)) e
 
 		// reconfiguring is successful up until this point, so it can stay in the
 		// current list of clients.  it may be moved later by the Reconfigure callback.
-		numReconfigured++
+
+		// if the pool name changed as part of this reconfigure, move it.
+		if oldPoolName != newPoolName {
+			p.connCountMetric.Record(context.Background(), -1, metric.WithAttributes(
+				semconv.DBSystemCouchbase,
+				semconv.DBClientConnectionsPoolName(oldPoolName),
+			))
+
+			p.connCountMetric.Record(context.Background(), 1, metric.WithAttributes(
+				semconv.DBSystemCouchbase,
+				semconv.DBClientConnectionsPoolName(newPoolName),
+			))
+		}
 	}
 
 	p.rebuildActiveClientsLocked()
 	p.checkConnectionsLocked()
-
-	if oldPoolName != newPoolName {
-		p.connCountMetric.Record(context.Background(), -int64(numReconfigured), metric.WithAttributes(
-			semconv.DBSystemCouchbase,
-			semconv.DBClientConnectionsPoolName(oldPoolName),
-		))
-
-		p.connCountMetric.Record(context.Background(), int64(numReconfigured), metric.WithAttributes(
-			semconv.DBSystemCouchbase,
-			semconv.DBClientConnectionsPoolName(newPoolName),
-		))
-	}
 
 	return nil
 }

--- a/memdx/client.go
+++ b/memdx/client.go
@@ -2,6 +2,7 @@ package memdx
 
 import (
 	"errors"
+	"net"
 	"os"
 	"sync"
 
@@ -246,10 +247,10 @@ func (c *Client) Dispatch(req *Packet, handler DispatchCallback) (PendingOp, err
 	}, nil
 }
 
-func (c *Client) LocalAddr() string {
+func (c *Client) LocalAddr() net.Addr {
 	return c.conn.LocalAddr()
 }
 
-func (c *Client) RemoteAddr() string {
+func (c *Client) RemoteAddr() net.Addr {
 	return c.conn.RemoteAddr()
 }

--- a/memdx/conn.go
+++ b/memdx/conn.go
@@ -91,10 +91,10 @@ func (c *Conn) Close() error {
 	return c.conn.Close()
 }
 
-func (c *Conn) LocalAddr() string {
-	return c.conn.LocalAddr().String()
+func (c *Conn) LocalAddr() net.Addr {
+	return c.conn.LocalAddr()
 }
 
-func (c *Conn) RemoteAddr() string {
-	return c.conn.RemoteAddr().String()
+func (c *Conn) RemoteAddr() net.Addr {
+	return c.conn.RemoteAddr()
 }

--- a/memdx/dispatcher.go
+++ b/memdx/dispatcher.go
@@ -8,6 +8,4 @@ type DispatchCallback func(*Packet, error) bool
 
 type Dispatcher interface {
 	Dispatch(*Packet, DispatchCallback) (PendingOp, error)
-	LocalAddr() string
-	RemoteAddr() string
 }

--- a/memdx/errors.go
+++ b/memdx/errors.go
@@ -114,22 +114,18 @@ func (e invalidArgError) Unwrap() error {
 }
 
 type ServerError struct {
-	OpCode         OpCode
-	Status         Status
-	Cause          error
-	DispatchedTo   string
-	DispatchedFrom string
-	Opaque         uint32
+	OpCode OpCode
+	Status Status
+	Cause  error
+	Opaque uint32
 }
 
 func (e ServerError) Error() string {
 	return fmt.Sprintf(
-		"server error: %s, status: 0x%x, opcode: %s, dispatched from: %s, dispatched to: %s, opaque: %d",
+		"server error: %s, status: 0x%x, opcode: %s, opaque: %d",
 		e.Cause,
 		uint16(e.Status),
 		e.OpCode.String(),
-		e.DispatchedFrom,
-		e.DispatchedTo,
 		e.Opaque,
 	)
 }

--- a/memdx/errors_test.go
+++ b/memdx/errors_test.go
@@ -14,10 +14,8 @@ func TestServerErrorWithContextText(t *testing.T) {
 
 	err := &ServerErrorWithContext{
 		Cause: ServerError{
-			Cause:          errors.New("invalid"),
-			DispatchedTo:   "",
-			DispatchedFrom: "",
-			Opaque:         1,
+			Cause:  errors.New("invalid"),
+			Opaque: 1,
 		},
 		ContextJson: text,
 	}

--- a/memdx/harness_int_test.go
+++ b/memdx/harness_int_test.go
@@ -2,9 +2,10 @@ package memdx_test
 
 import (
 	"context"
-	"encoding/json"
+	"net"
 	"testing"
 
+	"github.com/couchbase/gocbcorex/contrib/cbconfig"
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/couchbase/gocbcorex/testutilsint"
 	"github.com/stretchr/testify/require"
@@ -22,15 +23,9 @@ func createTestClient(t *testing.T) *memdx.Client {
 
 	// As we tie commands to a vbucket we have to ensure that the client we're returning is
 	// actually connected to the right node.
-	type vbucketServerMap struct {
-		ServerList []string `json:"serverList"`
-		VBucketMap [][]int  `json:"vBucketMap,omitempty"`
-	}
-	type cbConfig struct {
-		VBucketServerMap vbucketServerMap `json:"vBucketServerMap"`
-	}
-	var config cbConfig
-	require.NoError(t, json.Unmarshal(resp.ClusterConfig.Config, &config))
+	nodeHostname, _, _ := net.SplitHostPort(testAddress)
+	config, err := cbconfig.ParseTerseConfig(resp.ClusterConfig.Config, nodeHostname)
+	require.NoError(t, err)
 
 	// This is all a bit rough and can be improved, in time.
 	vbIdx := config.VBucketServerMap.VBucketMap[defaultTestVbucketID][0]

--- a/memdx/ops_core_errors_test.go
+++ b/memdx/ops_core_errors_test.go
@@ -15,9 +15,6 @@ func TestOpsCoreDecodeError(t *testing.T) {
 		ExpectedError error
 	}
 
-	dispatchedTo := "endpoint1"
-	dispatchedFrom := "local1"
-
 	tests := []test{
 		{
 			Name: "NotMyVbucket",
@@ -30,12 +27,10 @@ func TestOpsCoreDecodeError(t *testing.T) {
 			},
 			ExpectedError: &ServerErrorWithConfig{
 				Cause: ServerError{
-					OpCode:         OpCodeReplace,
-					Status:         StatusNotMyVBucket,
-					Cause:          ErrNotMyVbucket,
-					DispatchedTo:   dispatchedTo,
-					DispatchedFrom: dispatchedFrom,
-					Opaque:         0x34,
+					OpCode: OpCodeReplace,
+					Status: StatusNotMyVBucket,
+					Cause:  ErrNotMyVbucket,
+					Opaque: 0x34,
 				},
 				ConfigJson: []byte("impretendingtobeaconfig"),
 			},
@@ -44,7 +39,7 @@ func TestOpsCoreDecodeError(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(tt *testing.T) {
-			err := OpsCore{}.decodeError(test.Pkt, dispatchedTo, dispatchedFrom)
+			err := OpsCore{}.decodeError(test.Pkt)
 
 			assert.Equal(t, test.ExpectedError, err)
 		})

--- a/memdx/ops_crud.go
+++ b/memdx/ops_crud.go
@@ -139,13 +139,13 @@ func (o OpsCrud) decodeCommonStatus(status Status) error {
 		return nil
 	}
 }
-func (o OpsCrud) decodeCommonError(resp *Packet, dispatchedTo string, dispatchedFrom string) error {
+func (o OpsCrud) decodeCommonError(resp *Packet) error {
 	err := OpsCrud{}.decodeCommonStatus(resp.Status)
 	if err != nil {
 		return err
 	}
 
-	return OpsCore{}.decodeError(resp, dispatchedTo, dispatchedFrom)
+	return OpsCore{}.decodeError(resp)
 }
 
 type GetRequest struct {
@@ -194,7 +194,7 @@ func (o OpsCrud) Get(d Dispatcher, req *GetRequest, cb func(*GetResponse, error)
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -278,7 +278,7 @@ func (o OpsCrud) GetAndTouch(d Dispatcher, req *GetAndTouchRequest, cb func(*Get
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -354,7 +354,7 @@ func (o OpsCrud) GetReplica(d Dispatcher, req *GetReplicaRequest, cb func(*GetRe
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -438,7 +438,7 @@ func (o OpsCrud) GetAndLock(d Dispatcher, req *GetAndLockRequest, cb func(*GetAn
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -514,7 +514,7 @@ func (o OpsCrud) GetRandom(d Dispatcher, req *GetRandomRequest, cb func(*GetRand
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -625,7 +625,7 @@ func (o OpsCrud) Set(d Dispatcher, req *SetRequest, cb func(*SetResponse, error)
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -706,7 +706,7 @@ func (o OpsCrud) Unlock(d Dispatcher, req *UnlockRequest, cb func(*UnlockRespons
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -786,7 +786,7 @@ func (o OpsCrud) Touch(d Dispatcher, req *TouchRequest, cb func(*TouchResponse, 
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -878,7 +878,7 @@ func (o OpsCrud) Delete(d Dispatcher, req *DeleteRequest, cb func(*DeleteRespons
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -981,7 +981,7 @@ func (o OpsCrud) Add(d Dispatcher, req *AddRequest, cb func(*AddResponse, error)
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1097,7 +1097,7 @@ func (o OpsCrud) Replace(d Dispatcher, req *ReplaceRequest, cb func(*ReplaceResp
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1201,7 +1201,7 @@ func (o OpsCrud) Append(d Dispatcher, req *AppendRequest, cb func(*AppendRespons
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1305,7 +1305,7 @@ func (o OpsCrud) Prepend(d Dispatcher, req *PrependRequest, cb func(*PrependResp
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1413,7 +1413,7 @@ func (o OpsCrud) Increment(d Dispatcher, req *IncrementRequest, cb func(*Increme
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1528,7 +1528,7 @@ func (o OpsCrud) Decrement(d Dispatcher, req *DecrementRequest, cb func(*Decreme
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1620,7 +1620,7 @@ func (o OpsCrud) GetMeta(d Dispatcher, req *GetMetaRequest, cb func(*GetMetaResp
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1719,7 +1719,7 @@ func (o OpsCrud) SetMeta(d Dispatcher, req *SetMetaRequest, cb func(*SetMetaResp
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1810,7 +1810,7 @@ func (o OpsCrud) DeleteMeta(d Dispatcher, req *DeleteMetaRequest, cb func(*Delet
 			cb(nil, ErrDocNotFound)
 			return false
 		} else if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -1936,7 +1936,7 @@ func (o OpsCrud) LookupIn(d Dispatcher, req *LookupInRequest, cb func(*LookupInR
 			docIsDeleted = true
 			// considered a success still
 		} else if resp.Status != StatusSuccess && resp.Status != StatusSubDocMultiPathFailure {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -2216,7 +2216,7 @@ func (o OpsCrud) MutateIn(d Dispatcher, req *MutateInRequest, cb func(*MutateInR
 			docIsDeleted = true
 			// considered a success still
 		} else if resp.Status != StatusSuccess && resp.Status != StatusSubDocMultiPathFailure {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 

--- a/memdx/ops_crud_rangescan.go
+++ b/memdx/ops_crud_rangescan.go
@@ -45,7 +45,7 @@ func (o OpsCrud) RangeScanCreate(d Dispatcher, req *RangeScanCreateRequest, cb f
 			cb(nil, ErrRangeScanVbUuidMismatch)
 			return false
 		} else if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -98,7 +98,7 @@ func (o OpsCrud) RangeScanContinue(d Dispatcher, req *RangeScanContinueRequest, 
 			return false
 		} else if resp.Status != StatusSuccess && resp.Status != StatusRangeScanMore &&
 			resp.Status != StatusRangeScanComplete {
-			actionCb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			actionCb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 
@@ -169,7 +169,7 @@ func (o OpsCrud) RangeScanCancel(d Dispatcher, req *RangeScanCancelRequest, cb f
 			cb(nil, ErrRangeScanNotFound)
 			return false
 		} else if resp.Status != StatusSuccess {
-			cb(nil, OpsCrud{}.decodeCommonError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCrud{}.decodeCommonError(resp))
 			return false
 		}
 

--- a/memdx/ops_utils.go
+++ b/memdx/ops_utils.go
@@ -70,7 +70,7 @@ func (o OpsUtils) Stats(d Dispatcher, req *StatsRequest, cb func(*StatsResponse,
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCore{}.decodeError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCore{}.decodeError(resp))
 			return false
 		}
 
@@ -122,13 +122,13 @@ func (o OpsUtils) GetCollectionID(d Dispatcher, req *GetCollectionIDRequest, cb 
 
 		if resp.Status == StatusScopeUnknown {
 			cb(nil, &ResourceError{
-				Cause:     OpsCore{}.decodeErrorContext(resp, ErrUnknownScopeName, "", ""),
+				Cause:     OpsCore{}.decodeErrorContext(resp, ErrUnknownScopeName),
 				ScopeName: req.ScopeName,
 			})
 			return false
 		} else if resp.Status == StatusCollectionUnknown {
 			cb(nil, &ResourceError{
-				Cause:          OpsCore{}.decodeErrorContext(resp, ErrUnknownCollectionName, "", ""),
+				Cause:          OpsCore{}.decodeErrorContext(resp, ErrUnknownCollectionName),
 				ScopeName:      req.ScopeName,
 				CollectionName: req.CollectionName,
 			})
@@ -136,7 +136,7 @@ func (o OpsUtils) GetCollectionID(d Dispatcher, req *GetCollectionIDRequest, cb 
 		}
 
 		if resp.Status != StatusSuccess {
-			cb(nil, OpsCore{}.decodeError(resp, d.RemoteAddr(), d.LocalAddr()))
+			cb(nil, OpsCore{}.decodeError(resp))
 			return false
 		}
 

--- a/memdxclient.go
+++ b/memdxclient.go
@@ -1,0 +1,16 @@
+package gocbcorex
+
+import (
+	"net"
+
+	"github.com/couchbase/gocbcorex/memdx"
+)
+
+type MemdxClient interface {
+	memdx.Dispatcher
+	LocalAddr() net.Addr
+	RemoteAddr() net.Addr
+	Close() error
+}
+
+var _ MemdxClient = (*memdx.Client)(nil)

--- a/utils.go
+++ b/utils.go
@@ -22,6 +22,19 @@ func getHostFromUri(uri string) (string, error) {
 	return parsedUrl.Host, nil
 }
 
+func hostnameFromAddrStr(address string) string {
+	host, _, err := net.SplitHostPort(address)
+	if err != nil {
+		return address
+	}
+	return host
+}
+
+func hostPortFromNetAddr(addr net.Addr) (string, int) {
+	tcpAddr := addr.(*net.TCPAddr)
+	return tcpAddr.IP.String(), tcpAddr.Port
+}
+
 func hostFromHostPort(hostport string) (string, error) {
 	host, _, err := net.SplitHostPort(hostport)
 	if err != nil {


### PR DESCRIPTION
This commit also refactors how we deal with remote hostnames and addresses with the various clients and connections inside of the library.  Primarily with the intent of simplifying the interfaces that we expose, and ensuring the correct details are available in the right places.