### PR TITLE
ING-989: Fixed memd status code 0x6 to be DeltaBadval.

### DIFF
--- a/memdx/errors.go
+++ b/memdx/errors.go
@@ -22,7 +22,7 @@ var (
 	ErrCasMismatch                         = errors.New("cas mismatch")
 	ErrDocLocked                           = errors.New("document locked")
 	ErrDocNotLocked                        = errors.New("document not locked")
-	ErrBadDelta                            = errors.New("bad delta")
+	ErrDeltaBadval                         = errors.New("bad document value for delta operation")
 	ErrAccessError                         = errors.New("access error")
 	ErrRangeScanEmpty                      = errors.New("range scan range was empty")
 	ErrRangeScanSeqNoNotFound              = errors.New("range scan sequence number not found")

--- a/memdx/ops_crud.go
+++ b/memdx/ops_crud.go
@@ -1401,8 +1401,8 @@ func (o OpsCrud) Increment(d Dispatcher, req *IncrementRequest, cb func(*Increme
 		} else if resp.Status == StatusLocked {
 			cb(nil, ErrDocLocked)
 			return false
-		} else if resp.Status == StatusBadDelta {
-			cb(nil, ErrBadDelta)
+		} else if resp.Status == StatusDeltaBadval {
+			cb(nil, ErrDeltaBadval)
 			return false
 		} else if resp.Status == StatusSyncWriteAmbiguous {
 			cb(nil, ErrSyncWriteAmbiguous)
@@ -1519,8 +1519,8 @@ func (o OpsCrud) Decrement(d Dispatcher, req *DecrementRequest, cb func(*Decreme
 		} else if resp.Status == StatusLocked {
 			cb(nil, ErrDocLocked)
 			return false
-		} else if resp.Status == StatusBadDelta {
-			cb(nil, ErrBadDelta)
+		} else if resp.Status == StatusDeltaBadval {
+			cb(nil, ErrDeltaBadval)
 			return false
 		} else if resp.Status == StatusSyncWriteAmbiguous {
 			cb(nil, ErrSyncWriteAmbiguous)

--- a/memdx/ops_crud_int_test.go
+++ b/memdx/ops_crud_int_test.go
@@ -3434,7 +3434,7 @@ func TestOpsCrudCounterNonNumericDoc(t *testing.T) {
 		VbucketID:    defaultTestVbucketID,
 		Delta:        1,
 	})
-	require.ErrorIs(t, err, memdx.ErrBadDelta)
+	require.ErrorIs(t, err, memdx.ErrDeltaBadval)
 
 	_, err = memdx.SyncUnaryCall(memdx.OpsCrud{
 		CollectionsEnabled: true,
@@ -3445,7 +3445,7 @@ func TestOpsCrudCounterNonNumericDoc(t *testing.T) {
 		VbucketID:    defaultTestVbucketID,
 		Delta:        1,
 	})
-	require.ErrorIs(t, err, memdx.ErrBadDelta)
+	require.ErrorIs(t, err, memdx.ErrDeltaBadval)
 }
 
 type testCrudDispatcher struct {

--- a/memdx/status.go
+++ b/memdx/status.go
@@ -24,8 +24,8 @@ const (
 	// StatusNotStored occurs when the server fails to store a key.
 	StatusNotStored = Status(0x05)
 
-	// StatusBadDelta occurs when an invalid delta value is specified to a counter operation.
-	StatusBadDelta = Status(0x06)
+	// StatusDeltaBadval occurs when performing a counter op and the document is non-numeric.
+	StatusDeltaBadval = Status(0x06)
 
 	// StatusNotMyVBucket occurs when an operation is dispatched to a server which is
 	// non-authoritative for a specific vbucket.
@@ -262,8 +262,8 @@ func (s Status) String() string {
 		return "InvalidArgs"
 	case StatusNotStored:
 		return "NotStored"
-	case StatusBadDelta:
-		return "BadDelta"
+	case StatusDeltaBadval:
+		return "DeltaBadval"
 	case StatusNotMyVBucket:
 		return "NotMyVBucket"
 	case StatusNoBucket:


### PR DESCRIPTION
We previously have always called this BadDelta, but this name is not accurate for what this error is actually used for from memcached.