### PR TITLE
ING-737: Warn if server version is unsupported

### DIFF
--- a/contrib/cbconfig/cbconfig.go
+++ b/contrib/cbconfig/cbconfig.go
@@ -14,6 +14,7 @@ type ConfigDDocsJson struct {
 type FullNodeJson struct {
 	Status            string                                  `json:"status,omitempty"`
 	ClusterMembership string                                  `json:"clusterMembership,omitempty"`
+	Version           string                                  `json:"version,omitempty"`
 	ThisNode          bool                                    `json:"thisNode,omitempty"`
 	CouchApiBase      string                                  `json:"couchApiBase,omitempty"`
 	Hostname          string                                  `json:"hostname,omitempty"`


### PR DESCRIPTION
We want to be able to warn users when running stellar gateway if they are using an unsupported server version. This means that we need to parse the server version from the cluster config that we get from pinging the cluster.