### PR TITLE
ING-2002: Increase tolerance and add warmup to unit benchmark CI

### DIFF
--- a/.github/workflows/unit-benchmark.yml
+++ b/.github/workflows/unit-benchmark.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   benchmark:
-    if: false  # Temporarily disabled while investigating failures
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Code
@@ -38,7 +37,9 @@ jobs:
             --base-ref ${{ github.base_ref || 'master' }}
             --cpu=1
             --count=5
+            --warmup-count=1
+            --warmup-time=10ms
             --debug
             --bench "^BenchmarkCrud|BenchmarkQuery|BenchmarkSearch"
-            --tolerance=1.0
+            --tolerance=20.0
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Previously the tolerance for change in performance was set to 1% which is far too low, given the instability of the performance of the hardware GHAs are run on. The new tolerance of 20% is even at the very lowest end that is recommended in the benchdiff docs. As well as increasing the tolerance I also added a short warmup to avoid initial bursts where performance is bad causing false positives.