### PR TITLE
ING-2006: Stop logging Authenticator password in config log lines

### DIFF
--- a/authenticator.go
+++ b/authenticator.go
@@ -2,6 +2,9 @@ package gocbcorex
 
 import (
 	"crypto/tls"
+	"encoding/json"
+
+	"go.uber.org/zap/zapcore"
 )
 
 type Authenticator interface {
@@ -24,6 +27,23 @@ func (a *PasswordAuthenticator) GetCredentials(
 	service ServiceType, hostPort string,
 ) (string, string, error) {
 	return a.Username, a.Password, nil
+}
+
+// MarshalJSON ensures the password is never included when an authenticator
+// is inadvertently serialized, for instance by reflection-based logging.
+func (a PasswordAuthenticator) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Username string
+		Password string
+	}{
+		Username: a.Username,
+		Password: "REDACTED",
+	})
+}
+
+func (a PasswordAuthenticator) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("username", a.Username)
+	return nil
 }
 
 type kvClientAuth struct {

--- a/authenticator_test.go
+++ b/authenticator_test.go
@@ -1,0 +1,37 @@
+package gocbcorex
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestPasswordAuthenticatorLoggingDoesNotLeakPassword(t *testing.T) {
+	auth := &PasswordAuthenticator{
+		Username: "Administrator",
+		Password: "s3cr3tpassw0rd",
+	}
+
+	encoder := zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig())
+
+	fields := []zap.Field{
+		// reflection-based logging of a struct containing the authenticator,
+		// mirroring how configs were inadvertently logged
+		zap.Any("config", struct {
+			Authenticator Authenticator
+		}{
+			Authenticator: auth,
+		}),
+		zap.Any("auth", auth),
+		zap.Object("authObj", auth),
+	}
+
+	buf, err := encoder.EncodeEntry(zapcore.Entry{Message: "test"}, fields)
+	require.NoError(t, err)
+
+	assert.NotContains(t, buf.String(), auth.Password)
+	assert.Contains(t, buf.String(), auth.Username)
+}

--- a/bucketswatcher_http.go
+++ b/bucketswatcher_http.go
@@ -16,6 +16,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type BucketsWatcherHttpConfig struct {
@@ -31,6 +32,17 @@ type BucketsWatcherHttpReconfigureConfig struct {
 	HttpRoundTripper http.RoundTripper
 	Endpoints        []string
 	Authenticator    Authenticator
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, deliberately omitting
+// the authenticator which can contain the user's password.
+func (c BucketsWatcherHttpReconfigureConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return enc.AddArray("endpoints", zapcore.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
+		for _, endpoint := range c.Endpoints {
+			enc.AppendString(endpoint)
+		}
+		return nil
+	}))
 }
 
 type BucketsWatcherHttpOptions struct {
@@ -110,7 +122,7 @@ func (w *BucketsWatcherHttp) NumAgents() int {
 }
 
 func (w *BucketsWatcherHttp) Reconfigure(cfg *BucketsWatcherHttpReconfigureConfig) error {
-	w.logger.Debug("Reconfiguring", zap.Any("config", cfg))
+	w.logger.Debug("Reconfiguring", zap.Object("config", cfg))
 
 	w.stateLock.Lock()
 	w.state = &bucketsWatcherHttpState{

--- a/cbauthx/revrpcclient.go
+++ b/cbauthx/revrpcclient.go
@@ -141,7 +141,8 @@ func (r *RevRpcClient) Run() error {
 			resp = jsonrpcx.Proc1ArgMethod(req, r.handlers.Heartbeat)
 		default:
 			resp = jsonrpcx.ProcUnknownMethod(req, func(method string, params interface{}) {
-				log.Printf("received unexpected request (method:%s, params:%+v)", method, params)
+				// deliberately don't log the params, as they may contain credentials
+				log.Printf("received unexpected request (method:%s)", method)
 			})
 		}
 

--- a/kvclientbabysitter.go
+++ b/kvclientbabysitter.go
@@ -5,6 +5,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -12,6 +13,7 @@ import (
 	"github.com/couchbase/gocbcorex/memdx"
 	"github.com/google/uuid"
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 	"golang.org/x/exp/slices"
 )
 
@@ -19,6 +21,11 @@ type KvTargetTlsConfig struct {
 	RootCAs            *x509.CertPool
 	InsecureSkipVerify bool
 	CipherSuites       []uint16
+}
+
+func (v KvTargetTlsConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddBool("insecure-skip-verify", v.InsecureSkipVerify)
+	return nil
 }
 
 func (v KvTargetTlsConfig) Equals(o *KvTargetTlsConfig) bool {
@@ -30,6 +37,17 @@ func (v KvTargetTlsConfig) Equals(o *KvTargetTlsConfig) bool {
 type KvTarget struct {
 	Address   string
 	TLSConfig *KvTargetTlsConfig
+}
+
+func (v KvTarget) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	enc.AddString("address", v.Address)
+	enc.AddBool("tls", v.TLSConfig != nil)
+	if v.TLSConfig != nil {
+		if err := enc.AddObject("tls-config", v.TLSConfig); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func (v KvTarget) Equals(o KvTarget) bool {
@@ -61,6 +79,17 @@ type kvClientBabysitterClientConfig struct {
 	Target         KvTarget
 	Auth           KvClientAuth
 	SelectedBucket string
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, deliberately omitting
+// the authentication data which can contain the user's password.
+func (v kvClientBabysitterClientConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if err := enc.AddObject("target", v.Target); err != nil {
+		return err
+	}
+	enc.AddString("authType", fmt.Sprintf("%T", v.Auth))
+	enc.AddString("selectedBucket", v.SelectedBucket)
+	return nil
 }
 
 func (v kvClientBabysitterClientConfig) Equals(o kvClientBabysitterClientConfig) bool {
@@ -338,7 +367,7 @@ ClientBuildLoop:
 		}
 
 		p.logger.Info("creating new client kv client",
-			zap.Any("config", desiredConfig))
+			zap.Object("config", *desiredConfig))
 
 		for {
 			connectWaitPeriod := p.connectErrThrottlePeriod - time.Since(lastErrTime)

--- a/nodeswatcher_http.go
+++ b/nodeswatcher_http.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
 )
 
 type NodesWatcherHttpConfig struct {
@@ -20,6 +21,17 @@ type NodesWatcherHttpReconfigureConfig struct {
 	HttpRoundTripper http.RoundTripper
 	Endpoints        []string
 	Authenticator    Authenticator
+}
+
+// MarshalLogObject implements zapcore.ObjectMarshaler, deliberately omitting
+// the authenticator which can contain the user's password.
+func (c NodesWatcherHttpReconfigureConfig) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	return enc.AddArray("endpoints", zapcore.ArrayMarshalerFunc(func(enc zapcore.ArrayEncoder) error {
+		for _, endpoint := range c.Endpoints {
+			enc.AppendString(endpoint)
+		}
+		return nil
+	}))
 }
 
 type NodesWatcherHttpOptions struct {
@@ -110,7 +122,7 @@ func (nw *NodesWatcherHttp) Close() {
 }
 
 func (nw *NodesWatcherHttp) Reconfigure(cfg *NodesWatcherHttpReconfigureConfig) error {
-	nw.logger.Debug("Reconfiguring", zap.Any("config", cfg))
+	nw.logger.Debug("Reconfiguring", zap.Object("config", cfg))
 
 	nw.stateLock.Lock()
 	nw.state = &nodesWatcherHttpState{


### PR DESCRIPTION
`gocbcorex` logged the `Authenticator` — which can contain the user's plaintext password — when logging config structs via `zap.Any`, including at `info` level in the kv client babysitter.

The fix redacts the authenticator wherever these configs are logged, and hardens the secret-holder itself:

- Config types (`kvClientBabysitterClientConfig`, the bucket/node watcher reconfigure configs) now implement `MarshalLogObject` that omits the auth data, with their log calls switched to `zap.Object`.
- `PasswordAuthenticator` implements `MarshalJSON` and `MarshalLogObject` so any reflection-based logging that reaches it redacts the password rather than printing it.
- The cbauth revrpc unknown-method handler no longer logs raw params, which may carry credentials.

Note: the `MarshalJSON` change affects JSON serialization of `PasswordAuthenticator` everywhere, not just logging. No consumer in this repo round-trips it through JSON.